### PR TITLE
Add misc utils

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -138,6 +138,8 @@ IncludeBlocks: Regroup #Preserve
 IncludeCategories:
   - Regex: '^(<|")(gtest|gmock|isl|json)/'
     Priority: 4
+  - Regex: '^(<|")hack.h'
+    Priority: 6
   - Regex: "<(sys/|std)[[:alnum:]._]+>"
     Priority: 5
   - Regex: "<(assert|complex|w?ctype|errno|fenv|float|inttypes|iso646|limits|locale|(tg)?math|setjmp|signal|string|threads|time|[uw]char)\\.h>"

--- a/.clang-format
+++ b/.clang-format
@@ -144,7 +144,7 @@ IncludeCategories:
     Priority: 5
   - Regex: "<[[:alnum:]_]+>"
     Priority: 5
-  - Regex: '(<|")maze_solver/'
+  - Regex: '(<|")(maze_solver|misc_utils)/'
     Priority: 1
     CaseSensitive: true
   - Regex: '(<|")sdkconfig.h'

--- a/components/maze_solver/CMakeLists.txt
+++ b/components/maze_solver/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+  SRCS
+  INCLUDE_DIRS
+    include
+)

--- a/components/maze_solver/README.md
+++ b/components/maze_solver/README.md
@@ -1,0 +1,9 @@
+# Maze Solver
+
+Maze representation and solving algorithms.
+
+Representation and algorithms are based on the [Python simulator][sim repo].
+
+TODO: Add more context directly here.
+
+[sim repo]: https://github.com/Roynecro97/micromouse-py-sim

--- a/components/maze_solver/idf_component.yml
+++ b/components/maze_solver/idf_component.yml
@@ -1,0 +1,4 @@
+# dependencies:
+version: "0.0.1"
+description: "Library to manipulate and solve a Micromouse maze"
+url: "https://github.com/Roynecro97/micromouse-robot"

--- a/components/maze_solver/include/maze_solver/direction.h
+++ b/components/maze_solver/include/maze_solver/direction.h
@@ -1,8 +1,9 @@
 #ifndef MAZE_SOLVER_DIRECTION_H
 #define MAZE_SOLVER_DIRECTION_H
 
+#include <misc_utils/typing_utils.h>
+
 #include <array>
-#include <concepts>
 #include <limits>
 #include <numbers>
 
@@ -187,21 +188,22 @@ constexpr auto to_degrees(Direction d) noexcept
  * @param d A cardinal direction.
  * @return Clockwise-rotation angle (in radians) from the East direction.
  */
-template <std::floating_point F = float>
+template <ExtendedFloatingPoint F = float>
 constexpr auto to_radians(Direction d) noexcept
 {
+    using float_type = make_floating_point<F>;
     switch (d)
     {
     case Direction::North:
-        return -std::numbers::pi_v<F> / 2;
+        return F(-std::numbers::pi_v<float_type> / 2);
     case Direction::East:
         return F(0.0f);
     case Direction::South:
-        return std::numbers::pi_v<F> / 2;
+        return F(std::numbers::pi_v<float_type> / 2);
     case Direction::West:
-        return -std::numbers::pi_v<F>;
+        return F(-std::numbers::pi_v<float_type>);
     default:
-        return std::numeric_limits<F>::quiet_NaN();
+        return F(std::numeric_limits<float_type>::quiet_NaN());
     }
 }
 

--- a/components/maze_solver/include/maze_solver/direction.h
+++ b/components/maze_solver/include/maze_solver/direction.h
@@ -1,0 +1,234 @@
+#ifndef MAZE_SOLVER_DIRECTION_H
+#define MAZE_SOLVER_DIRECTION_H
+
+#include <array>
+#include <concepts>
+#include <limits>
+#include <numbers>
+
+namespace micromouse
+{
+
+enum class RelativeDirection
+{
+    Front,
+    Back,
+    Left,
+    Right,
+};
+
+/**
+ * @brief Invert the direction (left <-> right; front <-> back).
+ *
+ * @param rd The relative direction to invert.
+ * @return The inverted direction.
+ */
+constexpr auto invert(RelativeDirection rd) noexcept
+{
+    switch (rd)
+    {
+    case RelativeDirection::Front:
+        return RelativeDirection::Back;
+    case RelativeDirection::Back:
+        return RelativeDirection::Front;
+    case RelativeDirection::Left:
+        return RelativeDirection::Right;
+    case RelativeDirection::Right:
+        return RelativeDirection::Left;
+    }
+}
+
+constexpr auto enum2str(RelativeDirection rd) noexcept
+{
+    switch (rd)
+    {
+    case RelativeDirection::Front:
+        return "Front";
+    case RelativeDirection::Back:
+        return "Back";
+    case RelativeDirection::Left:
+        return "Left";
+    case RelativeDirection::Right:
+        return "Right";
+    default:
+        return "<invalid>";
+    }
+}
+
+inline constexpr std::array relative_directions{
+    RelativeDirection::Front,
+    RelativeDirection::Back,
+    RelativeDirection::Left,
+    RelativeDirection::Right,
+};
+
+/**
+ * @brief A cardinal direction.
+ * @note Values match the corresponding Wall enum values except multiple Directions cannot be mixed.
+ * @see Wall
+ */
+enum class Direction
+{
+    North = 0x1,
+    East = 0x2,
+    South = 0x4,
+    West = 0x8,
+};
+
+/**
+ * @brief Return the direction that is the result of turning left (90 degrees counter-clockwise).
+ *
+ * @param d The cardinal direction to turn from.
+ * @return The result of turning left.
+ */
+constexpr auto turn_left(Direction d) noexcept
+{
+    switch (d)
+    {
+    case Direction::North:
+        return Direction::West;
+    case Direction::East:
+        return Direction::North;
+    case Direction::South:
+        return Direction::East;
+    case Direction::West:
+        return Direction::South;
+    }
+}
+
+/**
+ * @brief Calculate the direction that is the result of turning right (90 degrees clockwise).
+ *
+ * @param d The cardinal direction to turn from.
+ * @return The result of turning right.
+ */
+constexpr auto turn_right(Direction d) noexcept
+{
+    switch (d)
+    {
+    case Direction::North:
+        return Direction::East;
+    case Direction::East:
+        return Direction::South;
+    case Direction::South:
+        return Direction::West;
+    case Direction::West:
+        return Direction::North;
+    }
+}
+
+/**
+ * @brief Calculate the direction that is the result of turning back (180 degrees).
+ *
+ * @param d The cardinal direction to turn from.
+ * @return The result of turning back.
+ */
+constexpr auto turn_back(Direction d) noexcept
+{
+    switch (d)
+    {
+    case Direction::North:
+        return Direction::South;
+    case Direction::East:
+        return Direction::West;
+    case Direction::South:
+        return Direction::North;
+    case Direction::West:
+        return Direction::East;
+    }
+}
+
+/**
+ * @brief Calculate the direction that is the result of turning in the provided relative direction.
+ *
+ * @param d The cardinal direction to turn from.
+ * @param rel The direction to turn to.
+ * @return The result of the turn.
+ */
+constexpr auto turn(Direction d, RelativeDirection rel) noexcept
+{
+    switch (rel)
+    {
+    case RelativeDirection::Front:
+        return d;
+    case RelativeDirection::Back:
+        return turn_back(d);
+    case RelativeDirection::Left:
+        return turn_left(d);
+    case RelativeDirection::Right:
+        return turn_right(d);
+    }
+}
+
+/**
+ * @brief Get the rotation degrees. East is 0 deg, degrees increase clockwise.
+ *
+ * @param d A cardinal direction.
+ * @return Clockwise-rotation degrees from the East direction.
+ */
+constexpr auto to_degrees(Direction d) noexcept
+{
+    switch (d)
+    {
+    case Direction::North:
+        return -90;
+    case Direction::East:
+        return 0;
+    case Direction::South:
+        return 90;
+    case Direction::West:
+        return 180;
+    }
+}
+
+/**
+ * @brief Get the rotation angle. East is 0, degrees increase clockwise.
+ *
+ * @param d A cardinal direction.
+ * @return Clockwise-rotation angle (in radians) from the East direction.
+ */
+template <std::floating_point F = float>
+constexpr auto to_radians(Direction d) noexcept
+{
+    switch (d)
+    {
+    case Direction::North:
+        return -std::numbers::pi_v<F> / 2;
+    case Direction::East:
+        return F(0.0f);
+    case Direction::South:
+        return std::numbers::pi_v<F> / 2;
+    case Direction::West:
+        return -std::numbers::pi_v<F>;
+    default:
+        return std::numeric_limits<F>::quiet_NaN();
+    }
+}
+
+constexpr auto enum2str(Direction d) noexcept
+{
+    switch (d)
+    {
+    case Direction::North:
+        return "North";
+    case Direction::East:
+        return "East";
+    case Direction::South:
+        return "South";
+    case Direction::West:
+        return "West";
+    default:
+        return "<invalid>";
+    }
+}
+
+inline constexpr std::array primary_directions{
+    Direction::North,
+    Direction::East,
+    Direction::South,
+    Direction::West,
+};
+
+}  // namespace micromouse
+
+#endif  // MAZE_SOLVER_DIRECTION_H

--- a/components/maze_solver/include/maze_solver/direction.h
+++ b/components/maze_solver/include/maze_solver/direction.h
@@ -37,6 +37,7 @@ constexpr auto invert(RelativeDirection rd) noexcept
     case RelativeDirection::Right:
         return RelativeDirection::Left;
     }
+    return rd;
 }
 
 constexpr auto enum2str(RelativeDirection rd) noexcept
@@ -95,6 +96,7 @@ constexpr auto turn_left(Direction d) noexcept
     case Direction::West:
         return Direction::South;
     }
+    return d;
 }
 
 /**
@@ -116,6 +118,7 @@ constexpr auto turn_right(Direction d) noexcept
     case Direction::West:
         return Direction::North;
     }
+    return d;
 }
 
 /**
@@ -137,6 +140,7 @@ constexpr auto turn_back(Direction d) noexcept
     case Direction::West:
         return Direction::East;
     }
+    return d;
 }
 
 /**
@@ -159,6 +163,7 @@ constexpr auto turn(Direction d, RelativeDirection rel) noexcept
     case RelativeDirection::Right:
         return turn_right(d);
     }
+    return d;
 }
 
 /**
@@ -178,8 +183,9 @@ constexpr auto to_degrees(Direction d) noexcept
     case Direction::South:
         return 90;
     case Direction::West:
-        return 180;
+        return -180;
     }
+    return 720;  // impossible value, should pop out
 }
 
 /**

--- a/components/misc_utils/CMakeLists.txt
+++ b/components/misc_utils/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+  SRCS
+  INCLUDE_DIRS
+    include
+)

--- a/components/misc_utils/README.md
+++ b/components/misc_utils/README.md
@@ -1,0 +1,6 @@
+# Misc Utils
+
+Various utilities that don't yet have a home.
+
+Utilities placed here are either extremely generic or simply don't yet have a
+home in the `maze_solver` or `main` components.

--- a/components/misc_utils/idf_component.yml
+++ b/components/misc_utils/idf_component.yml
@@ -1,0 +1,4 @@
+# dependencies:
+version: "0.0.1"
+description: "Miscellaneous utilities for the robot and the maze solver."
+url: "https://github.com/Roynecro97/micromouse-robot"

--- a/components/misc_utils/include/misc_utils/angle.h
+++ b/components/misc_utils/include/misc_utils/angle.h
@@ -1,7 +1,6 @@
 #ifndef MISC_UTILS_ANGLE_H
 #define MISC_UTILS_ANGLE_H
 
-#include "strongly_typed.h"
 #include "typing_utils.h"
 #include "value_range.h"
 

--- a/components/misc_utils/include/misc_utils/angle.h
+++ b/components/misc_utils/include/misc_utils/angle.h
@@ -1,0 +1,28 @@
+#ifndef MISC_UTILS_ANGLE_H
+#define MISC_UTILS_ANGLE_H
+
+#include "strongly_typed.h"
+#include "typing_utils.h"
+#include "value_range.h"
+
+#include <numbers>
+
+namespace micromouse
+{
+
+template <
+    PartialArithmetic T = float,
+    T Low = -std::numbers::pi_v<make_floating_point<T>>,
+    T Cycle = 2 * std::numbers::pi_v<make_floating_point<T>>>
+using BasicAngleRange = ValueRange<T, Low, Low + Cycle, Mode::RightOpen>;
+
+template <float Low = -std::numbers::pi_v<float>, float Cycle = 2 * std::numbers::pi_v<float>>
+using FloatingAngleRange = BasicAngleRange<float, Low, Cycle>;
+
+using AngleRange = FloatingAngleRange<>;
+
+using Angle = ConstrainedValue<AngleRange>;
+
+}  // namespace micromouse
+
+#endif  // MISC_UTILS_ANGLE_H

--- a/components/misc_utils/include/misc_utils/bits/physical_unit.h
+++ b/components/misc_utils/include/misc_utils/bits/physical_unit.h
@@ -8,19 +8,18 @@
 namespace micromouse
 {
 
-template <TString SI, TString Shorthand, typename Tag = decltype([] {})>
+template <char Shorthand>
 struct PhysicalUnit
 {
-    static constexpr const char *si_name = SI;
-    static constexpr const char *si_unit = Shorthand;
+    static constexpr char unit = Shorthand;
 };
 
 template <typename>
 struct is_physical_unit : std::false_type
 {};
 
-template <TString SI, TString Shorthand, typename Tag>
-struct is_physical_unit<PhysicalUnit<SI, Shorthand, Tag>> : std::true_type
+template <char Shorthand>
+struct is_physical_unit<PhysicalUnit<Shorthand>> : std::true_type
 {};
 
 template <typename T>
@@ -29,8 +28,8 @@ inline constexpr auto is_physical_unit_v = is_physical_unit<T>::value;
 template <typename T>
 concept PhysicalUnitType = is_physical_unit_v<T>;
 
-using Distance = PhysicalUnit<"meter", "m">;
-using Time = PhysicalUnit<"second", "s">;
+using Distance = PhysicalUnit<'m'>;
+using Time = PhysicalUnit<'s'>;
 
 }  // namespace micromouse
 

--- a/components/misc_utils/include/misc_utils/bits/physical_unit.h
+++ b/components/misc_utils/include/misc_utils/bits/physical_unit.h
@@ -1,0 +1,37 @@
+#ifndef MISC_UTILS_BITS_PHYSICAL_UNIT_H
+#define MISC_UTILS_BITS_PHYSICAL_UNIT_H
+
+#include "tstring.h"
+
+#include <type_traits>
+
+namespace micromouse
+{
+
+template <TString SI, TString Shorthand, typename Tag = decltype([] {})>
+struct PhysicalUnit
+{
+    static constexpr const char *si_name = SI;
+    static constexpr const char *si_unit = Shorthand;
+};
+
+template <typename>
+struct is_physical_unit : std::false_type
+{};
+
+template <TString SI, TString Shorthand, typename Tag>
+struct is_physical_unit<PhysicalUnit<SI, Shorthand, Tag>> : std::true_type
+{};
+
+template <typename T>
+inline constexpr auto is_physical_unit_v = is_physical_unit<T>::value;
+
+template <typename T>
+concept PhysicalUnitType = is_physical_unit_v<T>;
+
+using Distance = PhysicalUnit<"meter", "m">;
+using Time = PhysicalUnit<"second", "s">;
+
+}  // namespace micromouse
+
+#endif  // MISC_UTILS_BITS_PHYSICAL_UNIT_H

--- a/components/misc_utils/include/misc_utils/bits/tstring.h
+++ b/components/misc_utils/include/misc_utils/bits/tstring.h
@@ -1,0 +1,33 @@
+#ifndef MISC_UTILS_BITS_TSTRING_H
+#define MISC_UTILS_BITS_TSTRING_H
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+
+namespace micromouse
+{
+
+/**
+ * @brief A literal type for strings as non-type template parameters.
+ *
+ * @example template <TString S>
+ *          consteval auto operator""_str() noexcept
+ *          { return S; }
+ *
+ * @tparam N    Max size, don't specify when using as a non-type template parameter's type.
+ */
+template <std::size_t N>
+struct TString
+{
+    consteval TString() noexcept = default;
+    consteval TString(const char (&s)[N]) noexcept { std::copy(std::begin(s), std::end(s), value); }
+
+    consteval operator const char *() const noexcept { return value; }
+
+    char value[N]{};
+};
+
+}  // namespace micromouse
+
+#endif  // MISC_UTILS_BITS_TSTRING_H

--- a/components/misc_utils/include/misc_utils/bits/unit.h
+++ b/components/misc_utils/include/misc_utils/bits/unit.h
@@ -1,0 +1,95 @@
+#ifndef MISC_UTILS_BITS_UNIT_H
+#define MISC_UTILS_BITS_UNIT_H
+
+#include "physical_unit.h"
+#include "unit_list.h"
+
+#include <type_traits>
+
+namespace micromouse
+{
+
+template <UnitListType Numerator, UnitListType Denominator = UnitList<>>
+    requires (!unit_list_contains_any_v<Numerator, Denominator> && !unit_list_contains_any_v<Denominator, Numerator>)
+struct Unit
+{
+    using num = Numerator;
+    using den = Denominator;
+};
+
+template <typename T>
+struct is_unit : std::false_type
+{};
+
+template <UnitListType Numerator, UnitListType Denominator>
+struct is_unit<Unit<Numerator, Denominator>> : std::true_type
+{};
+
+template <typename T>
+inline constexpr auto is_unit_v = is_unit<T>::value;
+
+template <typename T>
+concept UnitSpec = is_unit_v<T>;
+
+namespace detail
+{
+
+template <UnitSpec, UnitSpec>
+struct unit_mul_helper;
+
+template <
+    UnitListType LhsNumerator,
+    UnitListType LhsDenominator,
+    UnitListType RhsNumerator,
+    UnitListType RhsDenominator>
+struct unit_mul_helper<Unit<LhsNumerator, LhsDenominator>, Unit<RhsNumerator, RhsDenominator>>
+{
+    using raw_numerator = unit_list_add<LhsNumerator, RhsNumerator>;
+    using raw_denominator = unit_list_add<LhsDenominator, RhsDenominator>;
+    using numerator = typename detail::unit_list_remove_helper<raw_numerator, raw_denominator>::type;
+    using denominator = typename detail::unit_list_remove_helper<raw_numerator, raw_denominator>::remainder;
+    using type = Unit<numerator, denominator>;
+};
+
+template <UnitSpec, UnitSpec>
+struct unit_div_helper;
+
+template <
+    UnitListType LhsNumerator,
+    UnitListType LhsDenominator,
+    UnitListType RhsNumerator,
+    UnitListType RhsDenominator>
+struct unit_div_helper<Unit<LhsNumerator, LhsDenominator>, Unit<RhsNumerator, RhsDenominator>>
+    : unit_mul_helper<Unit<LhsNumerator, LhsDenominator>, Unit<RhsDenominator, RhsNumerator>>
+{};
+
+}  // namespace detail
+
+template <UnitSpec Lhs, UnitSpec Rhs>
+using unit_mul = typename detail::unit_mul_helper<Lhs, Rhs>::type;
+
+template <UnitSpec Lhs, UnitSpec Rhs>
+using unit_div = typename detail::unit_div_helper<Lhs, Rhs>::type;
+
+template <UnitSpec T, UnitSpec U>
+struct units_equal : std::is_same<unit_div<T, U>, Unit<UnitList<>>>
+{};
+
+template <UnitSpec T, UnitSpec U>
+inline constexpr auto units_equal_v = units_equal<T, U>::value;
+
+namespace detail
+{
+template <typename T, typename U>
+concept SameUnitHelper = UnitSpec<T> && UnitSpec<U> && units_equal_v<T, U>;
+}  // namespace detail
+
+template <typename T, typename U>
+concept SameUnitAs = detail::SameUnitHelper<T, U> && detail::SameUnitHelper<U, T>;
+
+template <PhysicalUnitType... Units>
+using make_units = Unit<UnitList<Units...>>;
+
+}  // namespace micromouse
+
+#endif  // MISC_UTILS_BITS_UNIT_H

--- a/components/misc_utils/include/misc_utils/bits/unit_list.h
+++ b/components/misc_utils/include/misc_utils/bits/unit_list.h
@@ -1,0 +1,156 @@
+#ifndef MISC_UTILS_BITS_UNIT_LIST_H
+#define MISC_UTILS_BITS_UNIT_LIST_H
+
+#include "physical_unit.h"
+
+#include <type_traits>
+
+namespace micromouse
+{
+
+template <PhysicalUnitType...>
+struct UnitList;
+
+template <typename>
+struct is_unit_list : std::false_type
+{};
+
+template <PhysicalUnitType... Ts>
+struct is_unit_list<UnitList<Ts...>> : std::true_type
+{};
+
+template <typename T>
+inline constexpr auto is_unit_list_v = is_unit_list<T>::value;
+
+template <typename T>
+concept UnitListType = is_unit_list_v<T>;
+
+namespace detail
+{
+template <typename T>
+concept UnitListOrPhysicalUnit = UnitListType<T> || PhysicalUnitType<T>;
+}  // namespace detail
+
+template <UnitListType, PhysicalUnitType>
+struct unit_list_contains;
+
+template <PhysicalUnitType... Ts, PhysicalUnitType U>
+struct unit_list_contains<UnitList<Ts...>, U> : std::disjunction<std::is_same<Ts, U>...>
+{};
+
+template <UnitListType T, PhysicalUnitType U>
+inline constexpr auto unit_list_contains_v = unit_list_contains<T, U>::value;
+
+template <UnitListType, detail::UnitListOrPhysicalUnit>
+struct unit_list_contains_any;
+
+template <UnitListType T, PhysicalUnitType U>
+struct unit_list_contains_any<T, U> : unit_list_contains<T, U>
+{};
+
+template <UnitListType T, PhysicalUnitType... Us>
+struct unit_list_contains_any<T, UnitList<Us...>> : std::disjunction<unit_list_contains<T, Us>...>
+{};
+
+template <UnitListType T, detail::UnitListOrPhysicalUnit U>
+inline constexpr auto unit_list_contains_any_v = unit_list_contains_any<T, U>::value;
+
+template <UnitListType, detail::UnitListOrPhysicalUnit>
+struct unit_list_contains_all;
+
+template <UnitListType T, PhysicalUnitType U>
+struct unit_list_contains_all<T, U> : unit_list_contains<T, U>
+{};
+
+template <UnitListType T, PhysicalUnitType... Us>
+struct unit_list_contains_all<T, UnitList<Us...>> : std::conjunction<unit_list_contains<T, Us>...>
+{};
+
+template <UnitListType T, detail::UnitListOrPhysicalUnit U>
+inline constexpr auto unit_list_contains_all_v = unit_list_contains_all<T, U>::value;
+
+namespace detail
+{
+
+template <UnitListType, UnitListOrPhysicalUnit...>
+struct unit_list_add_helper;
+
+template <UnitListType T>
+struct unit_list_add_helper<T>
+{
+    using type = T;
+};
+
+template <PhysicalUnitType... Ts, PhysicalUnitType U, UnitListOrPhysicalUnit... Rest>
+struct unit_list_add_helper<UnitList<Ts...>, U, Rest...>
+{
+    using type = typename unit_list_add_helper<UnitList<Ts..., U>, Rest...>::type;
+};
+
+template <PhysicalUnitType... Ts, PhysicalUnitType... Us, UnitListOrPhysicalUnit... Rest>
+struct unit_list_add_helper<UnitList<Ts...>, UnitList<Us...>, Rest...>
+{
+    using type = typename unit_list_add_helper<UnitList<Ts..., Us...>, Rest...>::type;
+};
+
+}  // namespace detail
+
+template <UnitListType List, detail::UnitListOrPhysicalUnit... ToAdd>
+using unit_list_add = typename detail::unit_list_add_helper<List, ToAdd...>::type;
+
+namespace detail
+{
+
+template <UnitListType, UnitListOrPhysicalUnit>
+struct unit_list_remove_helper;
+
+template <PhysicalUnitType... Ts, PhysicalUnitType U>
+struct unit_list_remove_helper<UnitList<U, Ts...>, U>
+{
+    using type = UnitList<Ts...>;
+    using remainder = UnitList<>;
+};
+
+template <PhysicalUnitType T, PhysicalUnitType... Ts, PhysicalUnitType U>
+    requires (unit_list_contains_v<UnitList<Ts...>, U>)
+struct unit_list_remove_helper<UnitList<T, Ts...>, U>
+{
+    using type = unit_list_add<UnitList<T>, typename unit_list_remove_helper<UnitList<Ts...>, U>::type>;
+    using remainder = UnitList<>;
+};
+
+template <PhysicalUnitType... Ts, PhysicalUnitType U>
+    requires (!unit_list_contains_v<UnitList<Ts...>, U>)
+struct unit_list_remove_helper<UnitList<Ts...>, U>
+{
+    using type = UnitList<Ts...>;
+    using remainder = UnitList<U>;
+};
+
+template <UnitListType T>
+struct unit_list_remove_helper<T, UnitList<>>
+{
+    using type = T;
+    using remainder = UnitList<>;
+};
+
+template <UnitListType T, PhysicalUnitType U, PhysicalUnitType... Us>
+struct unit_list_remove_helper<T, UnitList<U, Us...>>
+{
+    using step = unit_list_remove_helper<T, U>;
+    using next_step = unit_list_remove_helper<typename step::type, UnitList<Us...>>;
+    using type = typename next_step::type;
+    using remainder = unit_list_add<typename step::remainder, typename next_step::remainder>;
+};
+
+}  // namespace detail
+
+template <UnitListType List, detail::UnitListOrPhysicalUnit... ToRemove>
+using unit_list_remove = typename detail::unit_list_remove_helper<List, ToRemove...>::type;
+
+template <UnitListType List, detail::UnitListOrPhysicalUnit... ToRemove>
+using unit_list_remove_remainder = typename detail::unit_list_remove_helper<List, ToRemove...>::remainder;
+
+}  // namespace micromouse
+
+#endif  // MISC_UTILS_BITS_UNIT_LIST_H

--- a/components/misc_utils/include/misc_utils/physical_size.h
+++ b/components/misc_utils/include/misc_utils/physical_size.h
@@ -82,25 +82,25 @@ public:
     using units = Units;
 
     constexpr PhysicalSize() noexcept = default;
-    explicit(!units_equal_v<Units, make_units<>>) constexpr PhysicalSize(rep val) noexcept : value(val) {}
+    explicit(!units_equal_v<units, make_units<>>) constexpr PhysicalSize(rep val) noexcept : value(val) {}
     template <typename... Args>
     explicit constexpr PhysicalSize(Args &&...args) noexcept : value(std::forward<Args>(args)...)
     {
     }
-    template <std::convertible_to<Rep> RepU, SameUnitAs<Units> UnitsU>
-        requires (!std::is_same_v<Units, UnitsU>)
-    constexpr PhysicalSize(PhysicalSize<RepU, UnitsU, Ratio> other) noexcept : value(other.count())
+    template <std::convertible_to<rep> RepU, SameUnitAs<units> UnitsU>
+        requires (!std::is_same_v<units, UnitsU>)
+    constexpr PhysicalSize(PhysicalSize<RepU, UnitsU, ratio> other) noexcept : value(other.count())
     {
     }
-    template <std::convertible_to<Rep> RepU>
-        requires (units_equal_v<Units, make_units<Time>>)
-    constexpr PhysicalSize(std::chrono::duration<RepU, Ratio> dur) noexcept : value(dur.count())
+    template <std::convertible_to<rep> RepU>
+        requires (units_equal_v<units, make_units<Time>>)
+    constexpr PhysicalSize(std::chrono::duration<RepU, ratio> dur) noexcept : value(dur.count())
     {
     }
 
     friend constexpr auto operator<=>(const PhysicalSize &lhs, const PhysicalSize &rhs) noexcept = default;
-    template <std::totally_ordered_with<Rep> RepU, SameUnitAs<Units> UnitsU>
-    friend constexpr auto operator<=>(const PhysicalSize &lhs, const PhysicalSize<RepU, UnitsU, Ratio> &rhs) noexcept
+    template <std::totally_ordered_with<rep> RepU, SameUnitAs<units> UnitsU>
+    friend constexpr auto operator<=>(const PhysicalSize &lhs, const PhysicalSize<RepU, UnitsU, ratio> &rhs) noexcept
     {
         return lhs.count() <=> rhs.count();
     }
@@ -146,110 +146,127 @@ public:
         value -= other.value;
         return *this;
     }
-    template <std::convertible_to<Rep> T>
-        requires requires (Rep a, T b) {
+    template <std::convertible_to<rep> T>
+        requires requires (rep a, T b) {
             { a *= b };
         }
-    constexpr auto &operator*=(const T &other) noexcept(noexcept(std::declval<Rep &>() *= other))
+    constexpr auto &operator*=(const T &other) noexcept(noexcept(std::declval<rep &>() *= other))
     {
         value *= other;
         return *this;
     }
-    template <std::convertible_to<Rep> T>
-        requires requires (Rep a, T b) {
+    template <std::convertible_to<rep> T>
+        requires requires (rep a, T b) {
             { a /= b };
         }
-    constexpr auto &operator/=(const T &other) noexcept(noexcept(std::declval<Rep &>() /= other))
+    constexpr auto &operator/=(const T &other) noexcept(noexcept(std::declval<rep &>() /= other))
     {
         value /= other;
         return *this;
     }
 
     template <UnitSpec UnitsU, RatioSpec RatioU>
-    friend constexpr auto operator*(const PhysicalSize &lhs, const PhysicalSize<Rep, UnitsU, RatioU> &rhs) noexcept
+    friend constexpr auto operator*(const PhysicalSize &lhs, const PhysicalSize<rep, UnitsU, RatioU> &rhs) noexcept
     {
-        return PhysicalSize<Rep, unit_mul<Units, UnitsU>, std::ratio_multiply<Ratio, RatioU>>(
+        return PhysicalSize<rep, unit_mul<units, UnitsU>, std::ratio_multiply<ratio, RatioU>>(
             lhs.count() * rhs.count()
         );
     }
     template <UnitSpec UnitsU, RatioSpec RatioU>
-    friend constexpr auto operator/(const PhysicalSize &lhs, const PhysicalSize<Rep, UnitsU, RatioU> &rhs) noexcept
+    friend constexpr auto operator/(const PhysicalSize &lhs, const PhysicalSize<rep, UnitsU, RatioU> &rhs) noexcept
     {
-        return PhysicalSize<Rep, unit_div<Units, UnitsU>, std::ratio_divide<Ratio, RatioU>>(lhs.count() / rhs.count());
+        return PhysicalSize<rep, unit_div<units, UnitsU>, std::ratio_divide<ratio, RatioU>>(lhs.count() / rhs.count());
     }
 
     template <PartialArithmetic RepU, RatioSpec RatioU>
-        requires (requires (Rep a, RepU b) {
-            { a * b } -> std::convertible_to<Rep>;
+        requires (requires (rep a, RepU b) {
+            { a * b } -> std::convertible_to<rep>;
         })
     friend constexpr auto operator*(const PhysicalSize &lhs, const std::chrono::duration<RepU, RatioU> &rhs)
-        noexcept(noexcept(std::declval<Rep>() * std::declval<RepU>()))
+        noexcept(noexcept(std::declval<rep>() * std::declval<RepU>()))
     {
-        return PhysicalSize<Rep, unit_mul<Units, make_units<Time>>, std::ratio_multiply<Ratio, RatioU>>(
+        return PhysicalSize<rep, unit_mul<units, make_units<Time>>, std::ratio_multiply<ratio, RatioU>>(
             lhs.count() * rhs.count()
         );
     }
     template <PartialArithmetic RepU, RatioSpec RatioU>
-        requires (requires (Rep a, RepU b) {
-            { a / b } -> std::convertible_to<Rep>;
+        requires (requires (rep a, RepU b) {
+            { a / b } -> std::convertible_to<rep>;
         })
     friend constexpr auto operator/(const PhysicalSize &lhs, const std::chrono::duration<RepU, RatioU> &rhs)
-        noexcept(noexcept(std::declval<Rep>() * std::declval<RepU>()))
+        noexcept(noexcept(std::declval<rep>() / std::declval<RepU>()))
     {
-        return PhysicalSize<Rep, unit_div<Units, make_units<Time>>, std::ratio_divide<Ratio, RatioU>>(
+        return PhysicalSize<rep, unit_div<units, make_units<Time>>, std::ratio_divide<ratio, RatioU>>(
             lhs.count() / rhs.count()
         );
     }
 
-    template <std::convertible_to<Rep> T>
-        requires requires (Rep a, T b) {
-            { a * b } -> std::convertible_to<Rep>;
+    template <PartialArithmetic RepU, RatioSpec RatioU>
+        requires (requires (RepU a, rep b) {
+            { a * b } -> std::convertible_to<rep>;
+        })
+    friend constexpr auto operator*(const std::chrono::duration<RepU, RatioU> &lhs, const PhysicalSize &rhs)
+        noexcept(noexcept(std::declval<rep>() * std::declval<RepU>()))
+    {
+        return PhysicalSize<RepU, unit_mul<Time, units>, std::ratio_multiply<RatioU, ratio>>(lhs.count() * rhs.count());
+    }
+    template <PartialArithmetic RepU, RatioSpec RatioU>
+        requires (requires (RepU a, rep b) {
+            { a / b } -> std::convertible_to<rep>;
+        })
+    friend constexpr auto operator/(const std::chrono::duration<RepU, RatioU> &lhs, const PhysicalSize &rhs)
+        noexcept(noexcept(std::declval<rep>() / std::declval<RepU>()))
+    {
+        return PhysicalSize<RepU, unit_div<Time, units>, std::ratio_divide<RatioU, ratio>>(lhs.count() / rhs.count());
+    }
+
+    template <std::convertible_to<rep> T>
+        requires requires (rep a, T b) {
+            { a * b } -> std::convertible_to<rep>;
         }
     friend constexpr auto operator*(const PhysicalSize &lhs, const T &rhs) noexcept(noexcept(lhs.count() * rhs))
     {
         return PhysicalSize(lhs.count() * rhs);
     }
-    template <std::convertible_to<Rep> T>
-        requires requires (Rep a, T b) {
-            { a / b } -> std::convertible_to<Rep>;
+    template <std::convertible_to<rep> T>
+        requires requires (rep a, T b) {
+            { a / b } -> std::convertible_to<rep>;
         }
     friend constexpr auto operator/(const PhysicalSize &lhs, const T &rhs) noexcept(noexcept(lhs.count() / rhs))
     {
         return PhysicalSize(lhs.count() / rhs);
     }
 
-    template <std::convertible_to<Rep> T>
-        requires requires (T a, Rep b) {
-            { a * b } -> std::convertible_to<Rep>;
+    template <std::convertible_to<rep> T>
+        requires requires (T a, rep b) {
+            { a * b } -> std::convertible_to<rep>;
         }
     friend constexpr auto operator*(const T &lhs, const PhysicalSize &rhs) noexcept(noexcept(lhs * rhs.count()))
     {
         return PhysicalSize(lhs * rhs.count());
     }
-    template <std::convertible_to<Rep> T>
-        requires requires (T a, Rep b) {
-            { a / b } -> std::convertible_to<Rep>;
+    template <std::convertible_to<rep> T>
+        requires requires (T a, rep b) {
+            { a / b } -> std::convertible_to<rep>;
         }
     friend constexpr auto operator/(const T &lhs, const PhysicalSize &rhs) noexcept(noexcept(lhs / rhs.count()))
     {
-        return PhysicalSize<Rep, unit_div<make_units<>, Units>, std::ratio_divide<std::ratio<1>, Ratio>>(
+        return PhysicalSize<rep, unit_div<make_units<>, units>, std::ratio_divide<std::ratio<1>, ratio>>(
             lhs / rhs.count()
         );
     }
 
     constexpr rep count() const noexcept { return value; }
-    static constexpr auto zero() noexcept { return PhysicalSize(PhysicalSizeValues<Rep>::zero()); }
-    static constexpr auto one() noexcept { return PhysicalSize(PhysicalSizeValues<Rep>::one()); }
-    static constexpr auto min() noexcept { return PhysicalSize(PhysicalSizeValues<Rep>::min()); }
-    static constexpr auto max() noexcept { return PhysicalSize(PhysicalSizeValues<Rep>::max()); }
+    static constexpr auto zero() noexcept { return PhysicalSize(PhysicalSizeValues<rep>::zero()); }
+    static constexpr auto one() noexcept { return PhysicalSize(PhysicalSizeValues<rep>::one()); }
+    static constexpr auto min() noexcept { return PhysicalSize(PhysicalSizeValues<rep>::min()); }
+    static constexpr auto max() noexcept { return PhysicalSize(PhysicalSizeValues<rep>::max()); }
 
-    constexpr std::chrono::duration<Rep, Ratio> to_duration() noexcept
-        requires (units_equal_v<Units, make_units<Time>>)
+    constexpr std::chrono::duration<rep, ratio> to_duration() noexcept
+        requires (units_equal_v<units, make_units<Time>>)
     {
-        return std::chrono::duration<Rep, Ratio>(count());
+        return std::chrono::duration<rep, ratio>(count());
     }
-
-    static consteval const char *units_str() { return ""; }
 
 private:
     rep value{};

--- a/components/misc_utils/include/misc_utils/physical_size.h
+++ b/components/misc_utils/include/misc_utils/physical_size.h
@@ -361,42 +361,42 @@ using meters_per_second = PhysicalSize<float, unit_div<Distance, Time>>;
 inline namespace unit_literals
 {
 
-consteval meters operator""_m(long double val)
+consteval auto operator""_m(long double val)
 {
     return meters(val);
 }
 
-consteval meters operator""_m(unsigned long long val)
+consteval auto operator""_m(unsigned long long val)
 {
     return meters(val);
 }
 
-consteval centimeters operator""_cm(long double val)
+consteval auto operator""_cm(long double val)
 {
     return centimeters(val);
 }
 
-consteval centimeters operator""_cm(unsigned long long val)
+consteval auto operator""_cm(unsigned long long val)
 {
     return centimeters(val);
 }
 
-consteval millimeters operator""_mm(long double val)
+consteval auto operator""_mm(long double val)
 {
     return millimeters(val);
 }
 
-consteval millimeters operator""_mm(unsigned long long val)
+consteval auto operator""_mm(unsigned long long val)
 {
     return millimeters(val);
 }
 
-consteval meters_per_second operator""_mps(long double val)
+consteval auto operator""_mps(long double val)
 {
     return meters_per_second(val);
 }
 
-consteval meters_per_second operator""_mps(unsigned long long val)
+consteval auto operator""_mps(unsigned long long val)
 {
     return meters_per_second(val);
 }

--- a/components/misc_utils/include/misc_utils/physical_size.h
+++ b/components/misc_utils/include/misc_utils/physical_size.h
@@ -335,6 +335,12 @@ constexpr ToSize unit_cast(const PhysicalSize<Rep, Units, Ratio> &ps)
     }
 }
 
+template <PartialArithmetic Rep, RatioSpec Ratio>
+PhysicalSize(const std::chrono::duration<Rep, Ratio> &) -> PhysicalSize<Rep, make_units<Time>, Ratio>;
+
+template <PartialArithmetic Rep>
+PhysicalSize(const Rep &) -> PhysicalSize<Rep>;
+
 template <RatioSpec ToRatio, PartialArithmetic Rep, UnitSpec Units, RatioSpec Ratio>
 constexpr auto unit_cast(const PhysicalSize<Rep, Units, Ratio> &ps)
 {

--- a/components/misc_utils/include/misc_utils/physical_size.h
+++ b/components/misc_utils/include/misc_utils/physical_size.h
@@ -356,6 +356,7 @@ constexpr auto unit_cast(const PhysicalSize<Rep, Units, Ratio> &ps)
 using meters = PhysicalSize<float, make_units<Distance>>;
 using centimeters = PhysicalSize<float, make_units<Distance>, std::centi>;
 using millimeters = PhysicalSize<float, make_units<Distance>, std::milli>;
+using meters_per_second = PhysicalSize<float, unit_div<Distance, Time>>;
 
 inline namespace unit_literals
 {
@@ -388,6 +389,16 @@ consteval millimeters operator""_mm(long double val)
 consteval millimeters operator""_mm(unsigned long long val)
 {
     return millimeters(val);
+}
+
+consteval meters_per_second operator""_mps(long double val)
+{
+    return meters_per_second(val);
+}
+
+consteval meters_per_second operator""_mps(unsigned long long val)
+{
+    return meters_per_second(val);
 }
 
 }  // namespace unit_literals

--- a/components/misc_utils/include/misc_utils/physical_size.h
+++ b/components/misc_utils/include/misc_utils/physical_size.h
@@ -191,9 +191,7 @@ public:
     friend constexpr auto operator*(const PhysicalSize &lhs, const std::chrono::duration<RepU, RatioU> &rhs)
         noexcept(noexcept(std::declval<rep>() * std::declval<RepU>()))
     {
-        return PhysicalSize<rep, unit_mul<units, make_units<Time>>, std::ratio_multiply<ratio, RatioU>>(
-            lhs.count() * rhs.count()
-        );
+        return PhysicalSize<rep, unit_mul<units, Time>, std::ratio_multiply<ratio, RatioU>>(lhs.count() * rhs.count());
     }
     template <PartialArithmetic RepU, RatioSpec RatioU>
         requires (requires (rep a, RepU b) {
@@ -202,9 +200,7 @@ public:
     friend constexpr auto operator/(const PhysicalSize &lhs, const std::chrono::duration<RepU, RatioU> &rhs)
         noexcept(noexcept(std::declval<rep>() / std::declval<RepU>()))
     {
-        return PhysicalSize<rep, unit_div<units, make_units<Time>>, std::ratio_divide<ratio, RatioU>>(
-            lhs.count() / rhs.count()
-        );
+        return PhysicalSize<rep, unit_div<units, Time>, std::ratio_divide<ratio, RatioU>>(lhs.count() / rhs.count());
     }
 
     template <PartialArithmetic RepU, RatioSpec RatioU>

--- a/components/misc_utils/include/misc_utils/strongly_typed.h
+++ b/components/misc_utils/include/misc_utils/strongly_typed.h
@@ -1,0 +1,340 @@
+#ifndef MISC_UTILS_STRONGLY_TYPED_H
+#define MISC_UTILS_STRONGLY_TYPED_H
+
+#include <compare>
+#include <concepts>
+#include <type_traits>
+#include <utility>
+
+namespace micromouse
+{
+
+/**
+ * @brief A base class for strongly typed wrappers.
+ *
+ * @example struct MyStrongInt : StronglyTyped<int, MyStrongInt>
+ *          {
+ *              using StronglyTyped<int, MyStrongInt>::StronglyTyped;
+ *          };
+ *
+ * @note Intended use is to publicly inherit from this struct and explicitly add a `using` directive for the
+ * constructor.
+ *
+ * @tparam T    Inner type.
+ * @tparam Tag  CRTP parameter.
+ */
+template <typename T, typename Tag>
+    requires (std::is_trivially_copyable_v<T>)
+struct StronglyTyped
+{
+    using type = T;
+    using Self = Tag;  // Prepare for default lambda tags...
+    // Tag is incomplete if using the `struct A: StronglyTyped<int, A> { ... };` form so this line is impossible:
+    // using Self = std::conditional_t<std::is_base_of_v<StronglyTyped, Tag>, Tag, StronglyTyped>;
+
+    constexpr StronglyTyped() noexcept : StronglyTyped(type{}) {}
+    explicit constexpr StronglyTyped(type val) noexcept : value(val) {}
+    template <typename... Args>
+    explicit constexpr StronglyTyped(Args &&...args) noexcept : value(std::forward<Args>(args)...)
+    {
+    }
+
+    constexpr StronglyTyped(const StronglyTyped &) noexcept = default;
+    constexpr StronglyTyped &operator=(const StronglyTyped &) noexcept = default;
+    constexpr StronglyTyped(StronglyTyped &&) noexcept = default;
+    constexpr StronglyTyped &operator=(StronglyTyped &&) noexcept = default;
+    ~StronglyTyped() noexcept = default;
+
+    constexpr type get() const noexcept { return value; }
+    explicit constexpr operator type() const noexcept { return get(); }
+
+    template <std::constructible_from<type> U>
+        requires (!std::is_same_v<type, U>)
+    explicit constexpr operator U() const noexcept(noexcept(U(std::declval<type>())))
+    {
+        return static_cast<U>(get());
+    }
+
+    friend constexpr auto operator<=>(const StronglyTyped &lhs, const StronglyTyped &rhs)
+        noexcept(noexcept(lhs.value <=> rhs.value))
+        requires (std::totally_ordered<type>)
+    = default;
+
+    friend constexpr auto operator<=>(const StronglyTyped &lhs, const type &rhs) noexcept(noexcept(lhs.value <=> rhs))
+        requires (std::totally_ordered<type>)
+    {
+        return lhs.value <=> rhs;
+    }
+
+    friend constexpr Self operator+(const StronglyTyped &val) noexcept(noexcept(+std::declval<type>()))
+        requires (requires (T a) {
+            { +a } -> std::convertible_to<type>;
+        })
+    {
+        return Self{+val.value};
+    }
+    friend constexpr Self operator-(const StronglyTyped &val) noexcept(noexcept(-std::declval<type>()))
+        requires (requires (T a) {
+            { -a } -> std::convertible_to<type>;
+        })
+    {
+        return Self{-val.value};
+    }
+    friend constexpr Self operator~(const StronglyTyped &val) noexcept(noexcept(~std::declval<type>()))
+        requires (requires (T a) {
+            { ~a } -> std::convertible_to<type>;
+        })
+    {
+        return Self{~val.value};
+    }
+    constexpr Self &operator++() noexcept(noexcept(++std::declval<type &>()))
+        requires (requires (T a) {
+            { ++a };
+        })
+    {
+        ++value;
+        return static_cast<Self &>(*this);
+    }
+    constexpr Self operator++(int) noexcept(noexcept(std::declval<type &>()++))
+        requires (requires (T a) {
+            { a++ } -> std::convertible_to<type>;
+        })
+    {
+        return Self{value++};
+    }
+    constexpr Self &operator--() noexcept(noexcept(--std::declval<type &>()))
+        requires (requires (T a) {
+            { --a };
+        })
+    {
+        --value;
+        return static_cast<Self &>(*this);
+    }
+    constexpr Self operator--(int) noexcept(noexcept(std::declval<type &>()--))
+        requires (requires (T a) {
+            { a-- } -> std::convertible_to<type>;
+        })
+    {
+        return Self{value--};
+    }
+
+    friend constexpr Self operator+(const StronglyTyped &lhs, const StronglyTyped &rhs)
+        noexcept(noexcept(lhs.value + rhs.value))
+        requires (requires (T a, T b) {
+            { a + b } -> std::convertible_to<type>;
+        })
+    {
+        return Self{lhs.value + rhs.value};
+    }
+    friend constexpr Self operator-(const StronglyTyped &lhs, const StronglyTyped &rhs)
+        noexcept(noexcept(lhs.value - rhs.value))
+        requires (requires (T a, T b) {
+            { a - b } -> std::convertible_to<type>;
+        })
+    {
+        return Self{lhs.value - rhs.value};
+    }
+    friend constexpr Self operator*(const StronglyTyped &lhs, const StronglyTyped &rhs)
+        noexcept(noexcept(lhs.value * rhs.value))
+        requires (requires (T a, T b) {
+            { a * b } -> std::convertible_to<type>;
+        })
+    {
+        return Self{lhs.value * rhs.value};
+    }
+    friend constexpr Self operator/(const StronglyTyped &lhs, const StronglyTyped &rhs)
+        noexcept(noexcept(lhs.value / rhs.value))
+        requires (requires (T a, T b) {
+            { a / b } -> std::convertible_to<type>;
+        })
+    {
+        return Self{lhs.value / rhs.value};
+    }
+    friend constexpr Self operator%(const StronglyTyped &lhs, const StronglyTyped &rhs)
+        noexcept(noexcept(lhs.value % rhs.value))
+        requires (requires (T a, T b) {
+            { a % b } -> std::convertible_to<type>;
+        })
+    {
+        return Self{lhs.value % rhs.value};
+    }
+    friend constexpr Self operator^(const StronglyTyped &lhs, const StronglyTyped &rhs)
+        noexcept(noexcept(lhs.value ^ rhs.value))
+        requires (requires (T a, T b) {
+            { a ^ b } -> std::convertible_to<type>;
+        })
+    {
+        return Self{lhs.value ^ rhs.value};
+    }
+    friend constexpr Self operator&(const StronglyTyped &lhs, const StronglyTyped &rhs)
+        noexcept(noexcept(lhs.value & rhs.value))
+        requires (requires (T a, T b) {
+            { a & b } -> std::convertible_to<type>;
+        })
+    {
+        return Self{lhs.value & rhs.value};
+    }
+    friend constexpr Self operator|(const StronglyTyped &lhs, const StronglyTyped &rhs)
+        noexcept(noexcept(lhs.value | rhs.value))
+        requires (requires (T a, T b) {
+            { a | b } -> std::convertible_to<type>;
+        })
+    {
+        return Self{lhs.value | rhs.value};
+    }
+    friend constexpr Self operator<<(const StronglyTyped &lhs, const StronglyTyped &rhs)
+        noexcept(noexcept(lhs.value << rhs.value))
+        requires (requires (T a, T b) {
+            { a << b } -> std::convertible_to<type>;
+        })
+    {
+        return Self{lhs.value << rhs.value};
+    }
+    friend constexpr Self operator>>(const StronglyTyped &lhs, const StronglyTyped &rhs)
+        noexcept(noexcept(lhs.value >> rhs.value))
+        requires (requires (T a, T b) {
+            { a >> b } -> std::convertible_to<type>;
+        })
+    {
+        return Self{lhs.value >> rhs.value};
+    }
+    template <typename U>
+    friend constexpr Self operator<<(const StronglyTyped &lhs, const U &rhs) noexcept(noexcept(lhs.value << rhs))
+        requires (requires (T a, U b) {
+            { a << b } -> std::convertible_to<type>;
+        })
+    {
+        return Self{lhs.value << rhs};
+    }
+    template <typename U>
+    friend constexpr Self operator>>(const StronglyTyped &lhs, const U &rhs) noexcept(noexcept(lhs.value >> rhs))
+        requires (requires (T a, U b) {
+            { a >> b } -> std::convertible_to<type>;
+        })
+    {
+        return Self{lhs.value >> rhs};
+    }
+
+    Self &operator+=(const StronglyTyped &other) noexcept(noexcept(value += other.value))
+        requires (requires (T a, T b) {
+            { a += b };
+        })
+    {
+        value += other.value;
+        return static_cast<Self &>(*this);
+    }
+    Self &operator-=(const StronglyTyped &other) noexcept(noexcept(value -= other.value))
+        requires (requires (T a, T b) {
+            { a -= b };
+        })
+    {
+        value -= other.value;
+        return static_cast<Self &>(*this);
+    }
+    Self &operator*=(const StronglyTyped &other) noexcept(noexcept(value *= other.value))
+        requires (requires (T a, T b) {
+            { a *= b };
+        })
+    {
+        value *= other.value;
+        return static_cast<Self &>(*this);
+    }
+    Self &operator/=(const StronglyTyped &other) noexcept(noexcept(value /= other.value))
+        requires (requires (T a, T b) {
+            { a /= b };
+        })
+    {
+        value /= other.value;
+        return static_cast<Self &>(*this);
+    }
+    Self &operator%=(const StronglyTyped &other) noexcept(noexcept(value %= other.value))
+        requires (requires (T a, T b) {
+            { a %= b };
+        })
+    {
+        value %= other.value;
+        return static_cast<Self &>(*this);
+    }
+    Self &operator^=(const StronglyTyped &other) noexcept(noexcept(value ^= other.value))
+        requires (requires (T a, T b) {
+            { a ^= b };
+        })
+    {
+        value ^= other.value;
+        return static_cast<Self &>(*this);
+    }
+    Self &operator&=(const StronglyTyped &other) noexcept(noexcept(value &= other.value))
+        requires (requires (T a, T b) {
+            { a &= b };
+        })
+    {
+        value &= other.value;
+        return static_cast<Self &>(*this);
+    }
+    Self &operator|=(const StronglyTyped &other) noexcept(noexcept(value |= other.value))
+        requires (requires (T a, T b) {
+            { a |= b };
+        })
+    {
+        value |= other.value;
+        return static_cast<Self &>(*this);
+    }
+    Self &operator<<=(const StronglyTyped &other) noexcept(noexcept(value <<= other.value))
+        requires (requires (T a, T b) {
+            { a <<= b };
+        })
+    {
+        value <<= other.value;
+        return static_cast<Self &>(*this);
+    }
+    Self &operator>>=(const StronglyTyped &other) noexcept(noexcept(value >>= other.value))
+        requires (requires (T a, T b) {
+            { a >>= b };
+        })
+    {
+        value >>= other.value;
+        return static_cast<Self &>(*this);
+    }
+
+    explicit constexpr operator bool() const noexcept(noexcept(static_cast<bool>(std::declval<type>())))
+        requires (std::is_nothrow_constructible_v<bool, type> && !std::is_same_v<bool, type>)
+    {
+        return static_cast<bool>(value);
+    }
+    constexpr bool operator!() const noexcept(noexcept(!std::declval<type>()))
+        requires (!std::is_same_v<type, bool> && requires (T a) {
+            { !a } -> std::same_as<bool>;
+        })
+    {
+        return !value;
+    }
+    constexpr Self operator!() const noexcept(noexcept(!std::declval<type>()))
+        requires (std::is_same_v<type, bool> || requires (T a) {
+            { !a };
+            requires !std::is_same_v<decltype(!a), bool>;
+            requires std::is_constructible_v<bool, decltype(!a)>;
+        })
+    {
+        return Self{!value};
+    }
+
+    type value;
+};
+
+template <typename T>
+struct is_strongly_typed : std::false_type
+{};
+
+template <typename T, typename Tag>
+struct is_strongly_typed<StronglyTyped<T, Tag>> : std::true_type
+{};
+
+template <typename T>
+inline constexpr auto is_strongly_typed_v = is_strongly_typed<T>::value;
+
+template <typename T>
+concept StrongType = is_strongly_typed_v<T>;
+
+}  // namespace micromouse
+
+#endif  // MISC_UTILS_STRONGLY_TYPED_H

--- a/components/misc_utils/include/misc_utils/strongly_typed.h
+++ b/components/misc_utils/include/misc_utils/strongly_typed.h
@@ -9,6 +9,9 @@
 namespace micromouse
 {
 
+template <typename T>
+struct is_strongly_typed;
+
 /**
  * @brief A base class for strongly typed wrappers.
  *
@@ -216,7 +219,7 @@ struct StronglyTypedBase
     }
     template <typename U>
     friend constexpr Self operator<<(const StronglyTypedBase &lhs, const U &rhs) noexcept(noexcept(lhs.value << rhs))
-        requires (requires (T a, U b) {
+        requires (!is_strongly_typed<U>::value && requires (T a, U b) {
             { a << b } -> std::convertible_to<type>;
         })
     {
@@ -224,7 +227,7 @@ struct StronglyTypedBase
     }
     template <typename U>
     friend constexpr Self operator>>(const StronglyTypedBase &lhs, const U &rhs) noexcept(noexcept(lhs.value >> rhs))
-        requires (requires (T a, U b) {
+        requires (!is_strongly_typed<U>::value && requires (T a, U b) {
             { a >> b } -> std::convertible_to<type>;
         })
     {

--- a/components/misc_utils/include/misc_utils/typing_utils.h
+++ b/components/misc_utils/include/misc_utils/typing_utils.h
@@ -1,0 +1,132 @@
+#ifndef MISC_UTILS_FLOATING_POINT_H
+#define MISC_UTILS_FLOATING_POINT_H
+
+#include <concepts>
+#include <numbers>
+#include <type_traits>
+
+namespace micromouse
+{
+
+namespace detail
+{
+
+template <typename T>
+concept PartialArithmeticHelper = requires (T a, T b) {
+    { +a } noexcept -> std::convertible_to<T>;
+    { ++a } noexcept -> std::same_as<T &>;
+    { a++ } noexcept -> std::convertible_to<T>;
+    { -a } noexcept -> std::convertible_to<T>;
+    { --a } noexcept -> std::same_as<T &>;
+    { a-- } noexcept -> std::convertible_to<T>;
+    { a + b } noexcept -> std::convertible_to<T>;
+    { a - b } noexcept -> std::convertible_to<T>;
+    { a * b } noexcept -> std::convertible_to<T>;
+    { a / b } noexcept -> std::convertible_to<T>;
+    // { a % b } noexcept -> std::convertible_to<T>;
+    { a = b } noexcept -> std::same_as<T &>;
+    { a += b } noexcept -> std::same_as<T &>;
+    { a -= b } noexcept -> std::same_as<T &>;
+    { a *= b } noexcept -> std::same_as<T &>;
+    { a /= b } noexcept -> std::same_as<T &>;
+    // { a %= b } noexcept -> std::same_as<T &>;
+    requires std::is_trivially_copyable_v<T>;
+    requires std::is_trivially_destructible_v<T>;
+    requires std::regular<T>;
+    requires std::totally_ordered<T>;
+    // Also require the comparisons to be noexcept
+    { a <=> b } noexcept;
+    { a == b } noexcept -> std::convertible_to<bool>;
+    { a != b } noexcept -> std::convertible_to<bool>;
+    { a < b } noexcept -> std::convertible_to<bool>;
+    { a <= b } noexcept -> std::convertible_to<bool>;
+    { a > b } noexcept -> std::convertible_to<bool>;
+    { a >= b } noexcept -> std::convertible_to<bool>;
+};
+
+}  // namespace detail
+
+template <typename T>
+concept Arithmetic = std::integral<T> || std::floating_point<T>;
+
+template <typename T>
+concept PartialArithmetic = Arithmetic<T> || detail::PartialArithmeticHelper<std::remove_cvref_t<T>>;
+
+template <typename T>
+struct is_arithmetic_wrapper : std::false_type
+{};
+
+template <PartialArithmetic T>
+    requires (Arithmetic<typename T::type>)
+struct is_arithmetic_wrapper<T> : std::true_type
+{};
+
+template <PartialArithmetic T>
+    requires (is_arithmetic_wrapper<typename T::type>::value)
+struct is_arithmetic_wrapper<T> : std::true_type
+{};
+
+template <typename T>
+inline constexpr bool is_arithmetic_wrapper_v = is_arithmetic_wrapper<T>::value;
+
+template <typename T>
+concept ArithmeticWrapper = is_arithmetic_wrapper_v<T> && PartialArithmetic<T>;
+
+template <typename T>
+concept ExtendedArithmetic = Arithmetic<T> || ArithmeticWrapper<T>;
+
+template <typename T>
+struct is_floating_point_wrapper : std::false_type
+{};
+
+template <PartialArithmetic T>
+    requires (std::floating_point<typename T::type>)
+struct is_floating_point_wrapper<T> : std::true_type
+{};
+
+template <PartialArithmetic T>
+    requires (is_floating_point_wrapper<typename T::type>::value)
+struct is_floating_point_wrapper<T> : std::true_type
+{};
+
+template <typename T>
+inline constexpr bool is_floating_point_wrapper_v = is_floating_point_wrapper<T>::value;
+
+template <typename T>
+concept FloatingPointWrapper = is_floating_point_wrapper_v<T>;
+
+template <typename T>
+concept ExtendedFloatingPoint = std::floating_point<T> || FloatingPointWrapper<T>;
+
+namespace detail
+{
+
+template <ExtendedFloatingPoint T>
+struct make_floating_point_helper;
+
+template <std::floating_point T>
+struct make_floating_point_helper<T>
+{
+    using type = T;
+};
+
+template <FloatingPointWrapper T>
+    requires std::floating_point<typename T::type>
+struct make_floating_point_helper<T>
+{
+    using type = typename T::type;
+};
+
+template <FloatingPointWrapper T>
+    requires (!std::floating_point<typename T::type>)
+struct make_floating_point_helper<T> : make_floating_point_helper<typename T::type>
+{};
+
+}  // namespace detail
+
+template <ExtendedFloatingPoint T>
+using make_floating_point = typename detail::make_floating_point_helper<T>::type;
+
+}  // namespace micromouse
+
+#endif  // MISC_UTILS_FLOATING_POINT_H

--- a/components/misc_utils/include/misc_utils/unit_symbols.h
+++ b/components/misc_utils/include/misc_utils/unit_symbols.h
@@ -169,7 +169,7 @@ consteval auto to_string(S val) noexcept
 template <PhysicalUnitType T>
 struct symbol_helper<T>
 {
-    static constexpr auto symbol = T::si_unit;
+    static constexpr TString symbol{{T::unit, '\0'}};
 };
 
 template <PhysicalUnitType... Ts>

--- a/components/misc_utils/include/misc_utils/unit_symbols.h
+++ b/components/misc_utils/include/misc_utils/unit_symbols.h
@@ -1,0 +1,368 @@
+#ifndef MISC_UTILS_UNIT_SYMBOLS_H
+#define MISC_UTILS_UNIT_SYMBOLS_H
+
+#include "bits/tstring.h"
+#include "physical_size.h"
+
+#include <algorithm>
+#include <array>
+#include <concepts>
+#include <cstddef>
+#include <iterator>
+#include <limits>
+#include <numeric>
+#include <ratio>
+#include <string_view>
+#include <type_traits>
+
+namespace micromouse
+{
+
+template <PhysicalUnitType T>
+consteval auto get_symbol()
+{
+    return T::si_unit;
+}
+
+namespace detail
+{
+
+template <UnitListType>
+struct reverse_unit_list_helper;
+
+template <>
+struct reverse_unit_list_helper<UnitList<>>
+{
+    using type = UnitList<>;
+};
+
+template <PhysicalUnitType T, PhysicalUnitType... Ts>
+struct reverse_unit_list_helper<UnitList<T, Ts...>>
+{
+    using type = unit_list_add<typename reverse_unit_list_helper<UnitList<Ts...>>::type, T>;
+};
+
+template <UnitListType T>
+using reverse_unit_list = typename reverse_unit_list_helper<T>::type;
+
+template <UnitListType T>
+struct make_reverse_unit_set
+{};
+
+template <>
+struct make_reverse_unit_set<UnitList<>>
+{
+    using type = UnitList<>;
+};
+
+template <PhysicalUnitType T, PhysicalUnitType... Ts>
+    requires (unit_list_contains_v<UnitList<Ts...>, T>)
+struct make_reverse_unit_set<UnitList<T, Ts...>>
+{
+    using type = typename make_reverse_unit_set<UnitList<Ts...>>::type;
+};
+
+template <PhysicalUnitType T, PhysicalUnitType... Ts>
+    requires (!unit_list_contains_v<UnitList<Ts...>, T>)
+struct make_reverse_unit_set<UnitList<T, Ts...>>
+{
+    using type = unit_list_add<typename make_reverse_unit_set<UnitList<Ts...>>::type, T>;
+};
+
+template <UnitListType T>
+struct make_unit_set
+{
+    using type = reverse_unit_list<typename make_reverse_unit_set<T>::type>;
+};
+
+template <UnitListType T>
+using unit_set = make_unit_set<T>::type;
+
+template <UnitListType, PhysicalUnitType, std::size_t C = 0>
+struct unit_list_count_helper : std::integral_constant<std::size_t, C>
+{};
+
+template <PhysicalUnitType T, PhysicalUnitType... Ts, PhysicalUnitType U, std::size_t C>
+struct unit_list_count_helper<UnitList<T, Ts...>, U, C>
+    : unit_list_count_helper<UnitList<Ts...>, U, C + static_cast<unsigned>(std::is_same_v<T, U>)>
+{};
+
+template <UnitListType T, PhysicalUnitType U>
+struct unit_list_count : unit_list_count_helper<T, U>
+{};
+
+template <UnitListType T, PhysicalUnitType U>
+inline constexpr auto unit_list_count_v = unit_list_count<T, U>::value;
+
+inline constexpr std::array digits = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+
+template <std::unsigned_integral U, U base = 10>
+    requires (base > 1 && base <= digits.size())
+consteval auto to_string(U val) noexcept
+{
+    TString<std::numeric_limits<U>::digits10 + 2> res{};
+    auto pos = std::end(res.value) - 1;
+    if (val == 0)
+    {
+        *--pos = digits[0];
+    }
+    else
+    {
+        while (val > 0)
+        {
+            *--pos = digits[val % base];
+            val /= base;
+        }
+    }
+    std::copy(pos, std::end(res.value), std::begin(res.value));
+    return res;
+}
+
+template <std::signed_integral S, S base = 10>
+    requires (base > 1 && base <= digits.size())
+consteval auto to_string(S val) noexcept
+{
+    TString<std::numeric_limits<S>::digits10 + 3> res{};
+    auto pos = std::end(res.value) - 1;
+    if (val == 0)
+    {
+        *--pos = digits[0];
+    }
+    else
+    {
+        bool neg = val < 0;
+        if (!neg)
+        {
+            val = -val;
+        }
+        while (val != 0)
+        {
+            *--pos = digits[-(val % base)];
+            val /= base;
+        }
+        if (neg)
+        {
+            *--pos = '-';
+        }
+    }
+    std::copy(pos, std::end(res.value), std::begin(res.value));
+    return res;
+}
+
+template <typename>
+struct symbol_helper;
+
+template <PhysicalUnitType... Ts>
+struct symbol_helper<UnitList<Ts...>>
+{
+    template <typename T>
+    static constexpr auto mkpair() noexcept
+    {
+        return std::pair(get_symbol<T>(), unit_list_count_v<UnitList<Ts...>, T>);
+    }
+
+    template <UnitListType = unit_set<UnitList<Ts...>>>
+    struct unique_helper;
+
+    template <PhysicalUnitType... Us>
+    struct unique_helper<UnitList<Us...>>
+    {
+        static constexpr auto mkextents_raw()
+        {
+            return std::array<std::pair<std::string_view, std::size_t>, sizeof...(Us)>{mkpair<Us>()...};
+        }
+    };
+
+    static constexpr auto mkextents()
+    {
+        auto arr = unique_helper<>::mkextents_raw();
+        std::sort(begin(arr), end(arr));
+        return arr;
+    }
+
+    static constexpr auto extents = mkextents();
+
+    static constexpr auto total_extent_len() noexcept
+    {
+        return std::accumulate(
+            begin(extents),
+            end(extents),
+            0UZ,
+            [](auto res, const auto &e) { return res + e.first.size() + ((e.second > 1) ? e.second + 1UZ : 0); }
+        );
+    }
+
+    static consteval auto mksymbol()
+    {
+        TString<total_extent_len() + 1> str{};
+        auto pos = std::begin(str.value);
+        for (auto &&e : extents)
+        {
+            std::copy(begin(e.first), end(e.first), pos);
+            pos += e.first.size();
+            if (e.second > 1)
+            {
+                *pos = '^';
+                auto pow = to_string(e.second);
+                auto pow_view = std::string_view(pow);
+                std::ranges::copy(begin(pow_view), end(pow_view), pos + 1);
+                pos += pow_view.size() + 1;
+            }
+        }
+        return str;
+    }
+
+    static constexpr auto symbol = mksymbol();
+};
+
+template <UnitSpec T>
+struct symbol_helper<T>
+{
+    static constexpr auto num_sym = std::string_view(detail::symbol_helper<typename T::num>::symbol);
+    static constexpr auto den_sym = std::string_view(detail::symbol_helper<typename T::den>::symbol);
+
+    static consteval auto get_symbol_impl()
+    {
+        TString<std::max(num_sym.size(), 1UZ) + den_sym.size() + ((den_sym.size() > 0) ? 2 : 1)> res{};
+        auto pos = std::begin(res.value);
+        if (num_sym.size() > 0)
+        {
+            std::copy(begin(num_sym), end(num_sym), pos);
+            pos += num_sym.size();
+        }
+        else
+        {
+            *pos = '1';
+            ++pos;
+        }
+        if (den_sym.size() > 0)
+        {
+            *pos = '/';
+            std::copy(begin(den_sym), end(den_sym), pos + 1);
+        }
+        return res;
+    }
+
+    static constexpr auto symbol = get_symbol_impl();
+};
+
+template <RatioSpec T>
+struct symbol_helper<T>
+{
+    static consteval auto get_symbol_impl()
+    {
+        if constexpr (T::num == 0)
+        {
+            return TString("0");
+        }
+        else
+        {
+            static constexpr auto num = detail::to_string(T::num);
+            static constexpr auto den = detail::to_string(T::den);
+            static constexpr auto num_view = std::string_view(num);
+            static constexpr auto den_view = std::string_view(den);
+            TString<num_view.size() + ((T::den != 1) ? den_view.size() + 2 : 1)> res;
+            auto pos = std::begin(res.value);
+            std::copy(begin(num_view), end(num_view), pos);
+            if (T::den != 1)
+            {
+                pos += num_view.size();
+                *pos = '/';
+                std::copy(begin(den_view), end(den_view), pos + 1);
+            }
+            return res;
+        }
+    }
+
+    static constexpr auto symbol = get_symbol_impl();
+};
+
+}  // namespace detail
+
+template <UnitListType T>
+consteval const char *get_symbol()
+{
+    return detail::symbol_helper<T>::symbol;
+}
+
+template <UnitSpec T>
+consteval const char *get_symbol()
+{
+    return detail::symbol_helper<T>::symbol;
+}
+
+template <>
+consteval const char *get_symbol<Unit<UnitList<>>>()
+{
+    return "";
+}
+
+template <>
+consteval const char *get_symbol<Unit<UnitList<>, UnitList<Time>>>()
+{
+    return "Hz";
+}
+
+template <RatioSpec T>
+consteval const char *get_symbol()
+{
+    return detail::symbol_helper<T>::symbol;
+}
+
+// clang-format off
+template <> consteval const char *get_symbol<std::atto>() { return "a"; }
+template <> consteval const char *get_symbol<std::femto>() { return "f"; }
+template <> consteval const char *get_symbol<std::pico>() { return "p"; }
+template <> consteval const char *get_symbol<std::nano>() { return "n"; }
+template <> consteval const char *get_symbol<std::micro>() { return "u"; }
+template <> consteval const char *get_symbol<std::milli>() { return "m"; }
+template <> consteval const char *get_symbol<std::centi>() { return "c"; }
+template <> consteval const char *get_symbol<std::deci>() { return "d"; }
+template <> consteval const char *get_symbol<std::deca>() { return "da"; }
+template <> consteval const char *get_symbol<std::hecto>() { return "h"; }
+template <> consteval const char *get_symbol<std::kilo>() { return "k"; }
+template <> consteval const char *get_symbol<std::mega>() { return "M"; }
+template <> consteval const char *get_symbol<std::giga>() { return "G"; }
+template <> consteval const char *get_symbol<std::tera>() { return "T"; }
+template <> consteval const char *get_symbol<std::peta>() { return "P"; }
+template <> consteval const char *get_symbol<std::exa>() { return "E"; }
+template <> consteval const char *get_symbol<std::ratio<1>>() { return ""; }
+// clang-format on
+
+namespace detail
+{
+
+template <PhysicalSizeType T>
+struct symbol_helper<T>
+{
+    static constexpr auto ratio = std::string_view(get_symbol<typename T::ratio>());
+    static constexpr auto units = std::string_view(get_symbol<typename T::units>());
+
+    static consteval auto get_symbol_impl()
+    {
+        TString<ratio.size() + units.size() + 1> res{};
+        std::copy(begin(ratio), end(ratio), res.value);
+        std::copy(begin(units), end(units), res.value + ratio.size());
+        return res;
+    }
+
+    static constexpr auto symbol = get_symbol_impl();
+};
+
+}  // namespace detail
+
+template <PhysicalSizeType T>
+consteval const char *get_symbol()
+{
+    return detail::symbol_helper<T>::symbol;
+}
+
+template <PhysicalSizeType T>
+consteval auto get_symbol(const T &)
+{
+    return get_symbol<T>();
+}
+
+}  // namespace micromouse
+
+#endif  // MISC_UTILS_UNIT_SYMBOLS_H

--- a/components/misc_utils/include/misc_utils/value_range.h
+++ b/components/misc_utils/include/misc_utils/value_range.h
@@ -23,6 +23,23 @@ enum class Mode
     LeftInclusive = RightOpen,
 };
 
+constexpr auto enum2str(Mode mode) noexcept
+{
+    switch (mode)
+    {
+    case Mode::Closed:
+        return "Closed";
+    case Mode::Open:
+        return "Open";
+    case Mode::LeftOpen:
+        return "LeftOpen";
+    case Mode::RightOpen:
+        return "RightOpen";
+    default:
+        return "<invalid>";
+    }
+}
+
 template <PartialArithmetic T, T Low, T High, Mode M, T Epsilon = T(1e-6)>
     requires (Low < High)
 class ValueRange

--- a/components/misc_utils/include/misc_utils/value_range.h
+++ b/components/misc_utils/include/misc_utils/value_range.h
@@ -57,38 +57,41 @@ public:
 
     static constexpr type clamp(type val) noexcept { return clamp_high(clamp_low(val)); }
 
+    static constexpr bool contains(type val) noexcept { return !out_of_range_low(val) && !out_of_range_high(val); }
+
 private:
-    static constexpr type fix_low(type val) noexcept
+    static constexpr bool out_of_range_low(type val) noexcept
         requires (is_left_open)
     {
-        while (val <= infimum + epsilon)
-        {
-            val += cycle;
-        }
-        return val;
+        return val <= infimum + epsilon;
     }
-    static constexpr type fix_low(type val) noexcept
+    static constexpr bool out_of_range_low(type val) noexcept
         requires (!is_left_open)
     {
-        while (val < minimum - epsilon)
+        return val < minimum - epsilon;
+    }
+    static constexpr bool out_of_range_high(type val) noexcept
+        requires (is_right_open)
+    {
+        return val >= supremum - epsilon;
+    }
+    static constexpr bool out_of_range_high(type val) noexcept
+        requires (!is_right_open)
+    {
+        return val > maximum + epsilon;
+    }
+
+    static constexpr type fix_low(type val) noexcept
+    {
+        while (out_of_range_low(val))
         {
             val += cycle;
         }
         return val;
     }
     static constexpr type fix_high(type val) noexcept
-        requires (is_right_open)
     {
-        while (val >= supremum - epsilon)
-        {
-            val -= cycle;
-        }
-        return val;
-    }
-    static constexpr type fix_high(type val) noexcept
-        requires (!is_right_open)
-    {
-        while (val > maximum + epsilon)
+        while (out_of_range_high(val))
         {
             val -= cycle;
         }
@@ -98,38 +101,22 @@ private:
     static constexpr type clamp_low(type val) noexcept
         requires (is_left_open)
     {
-        if (val <= infimum + epsilon)
-        {
-            return infimum + clamp_epsilon;
-        }
-        return val;
+        return out_of_range_low(val) ? infimum + clamp_epsilon : val;
     }
     static constexpr type clamp_low(type val) noexcept
         requires (!is_left_open)
     {
-        if (val < minimum - epsilon)
-        {
-            return minimum;
-        }
-        return val;
+        return out_of_range_low(val) ? minimum : val;
     }
     static constexpr type clamp_high(type val) noexcept
         requires (is_right_open)
     {
-        if (val >= supremum - epsilon)
-        {
-            return supremum - clamp_epsilon;
-        }
-        return val;
+        return out_of_range_high(val) ? supremum - clamp_epsilon : val;
     }
     static constexpr type clamp_high(type val) noexcept
         requires (!is_right_open)
     {
-        if (val > maximum + epsilon)
-        {
-            return maximum;
-        }
-        return val;
+        return out_of_range_high(val) ? maximum : val;
     }
 };
 

--- a/components/misc_utils/include/misc_utils/value_range.h
+++ b/components/misc_utils/include/misc_utils/value_range.h
@@ -186,17 +186,7 @@ struct ConstrainedValue<ValueRange<T, Low, High, M, Epsilon>, Cyclic>
     }
     friend constexpr auto operator-(const ConstrainedValue &lhs, const ConstrainedValue &rhs) noexcept
     {
-        if constexpr (cyclic)
-        {
-            using std::abs;
-            const auto a = lhs.get() - rhs.get();
-            const auto b = (lhs > rhs) ? (a - range_type::cycle) : (a + range_type::cycle);
-            return ConstrainedValue((abs(a) <= abs(b)) ? a : b);
-        }
-        else
-        {
-            return ConstrainedValue(lhs.value - rhs.value);
-        }
+        return ConstrainedValue(lhs.value - rhs.value);
     }
     friend constexpr auto operator*(const ConstrainedValue &lhs, const ConstrainedValue &rhs) noexcept
     {

--- a/components/misc_utils/include/misc_utils/value_range.h
+++ b/components/misc_utils/include/misc_utils/value_range.h
@@ -1,0 +1,255 @@
+#ifndef MISC_UTILS_VALUE_RANGE_H
+#define MISC_UTILS_VALUE_RANGE_H
+
+#include "typing_utils.h"
+
+#include <concepts>
+#include <type_traits>
+
+namespace micromouse
+{
+
+enum class Mode
+{
+    Closed,
+    Inclusive = Closed,
+    Open,
+    Exclusive = Open,
+    LeftOpen,
+    LeftExclusive = LeftOpen,
+    RightInclusive = LeftOpen,
+    RightOpen,
+    RightExclusive = RightOpen,
+    LeftInclusive = RightOpen,
+};
+
+template <PartialArithmetic T, T Low, T High, Mode M, T Epsilon = T(1e-6)>
+    requires (Low < High)
+class ValueRange
+{
+public:
+    using type = T;
+    static constexpr Mode mode = M;
+    static constexpr type low = Low;
+    static constexpr type high = High;
+    static constexpr type cycle = high - low;
+    static constexpr type epsilon = Epsilon;
+    static constexpr type clamp_epsilon = std::integral<T> ? 1 : epsilon;
+    static constexpr bool is_open = mode == Mode::Open;
+    static constexpr bool is_left_open = is_open || mode == Mode::LeftOpen;
+    static constexpr bool is_right_open = is_open || mode == Mode::RightOpen;
+    static constexpr bool is_closed = mode == Mode::Closed;
+
+    // For now, declare all 4 for clarity (because conditionally declaring them is not trivial)
+    // static constexpr std::enable_if_t<is_left_open, type> infimum = low;
+    // static constexpr std::enable_if_t<!is_left_open, type> minimum = low;
+    // static constexpr std::enable_if_t<is_right_open, type> supremum = high;
+    // static constexpr std::enable_if_t<!is_right_open, type> maximum = high;
+    static constexpr type infimum = low;
+    static constexpr type minimum = low;
+    static constexpr type supremum = high;
+    static constexpr type maximum = high;
+
+    static_assert(is_open == (is_left_open && is_right_open));
+    static_assert(is_closed == (!is_left_open && !is_right_open));
+
+    static constexpr type fix_cycle(type val) noexcept { return fix_high(fix_low(val)); }
+
+    static constexpr type clamp(type val) noexcept { return clamp_high(clamp_low(val)); }
+
+private:
+    static constexpr type fix_low(type val) noexcept
+        requires (is_left_open)
+    {
+        while (val <= infimum + epsilon)
+        {
+            val += cycle;
+        }
+        return val;
+    }
+    static constexpr type fix_low(type val) noexcept
+        requires (!is_left_open)
+    {
+        while (val < minimum - epsilon)
+        {
+            val += cycle;
+        }
+        return val;
+    }
+    static constexpr type fix_high(type val) noexcept
+        requires (is_right_open)
+    {
+        while (val >= supremum - epsilon)
+        {
+            val -= cycle;
+        }
+        return val;
+    }
+    static constexpr type fix_high(type val) noexcept
+        requires (!is_right_open)
+    {
+        while (val > maximum + epsilon)
+        {
+            val -= cycle;
+        }
+        return val;
+    }
+
+    static constexpr type clamp_low(type val) noexcept
+        requires (is_left_open)
+    {
+        if (val <= infimum + epsilon)
+        {
+            return infimum + clamp_epsilon;
+        }
+        return val;
+    }
+    static constexpr type clamp_low(type val) noexcept
+        requires (!is_left_open)
+    {
+        if (val < minimum - epsilon)
+        {
+            return minimum;
+        }
+        return val;
+    }
+    static constexpr type clamp_high(type val) noexcept
+        requires (is_right_open)
+    {
+        if (val >= supremum - epsilon)
+        {
+            return supremum - clamp_epsilon;
+        }
+        return val;
+    }
+    static constexpr type clamp_high(type val) noexcept
+        requires (!is_right_open)
+    {
+        if (val > maximum + epsilon)
+        {
+            return maximum;
+        }
+        return val;
+    }
+};
+
+struct unsafe_tag
+{
+} inline constexpr unsafe;
+
+template <typename ValueRange, bool Cyclic = true>
+struct ConstrainedValue;
+
+template <PartialArithmetic T, T Low, T High, Mode M, T Epsilon, bool Cyclic>
+struct ConstrainedValue<ValueRange<T, Low, High, M, Epsilon>, Cyclic>
+{
+    using range_type = ValueRange<T, Low, High, M, Epsilon>;
+    using type = typename range_type::type;
+    static constexpr auto cyclic = Cyclic;
+
+    constexpr ConstrainedValue() noexcept = default;
+    explicit constexpr ConstrainedValue(type val) noexcept : value(fix_value(val)) {}
+    explicit constexpr ConstrainedValue(unsafe_tag, type val) noexcept : value(val) {}
+
+    friend constexpr auto operator<=>(const ConstrainedValue &lhs, const ConstrainedValue &rhs) noexcept = default;
+    friend constexpr auto operator<=>(const ConstrainedValue &lhs, type rhs) noexcept { return lhs.get() <=> rhs; }
+
+    constexpr auto operator+() const noexcept { return ConstrainedValue(+value); }
+    constexpr auto &operator++() noexcept
+    {
+        ++value;
+        fix();
+        return *this;
+    }
+    constexpr auto operator++(int) noexcept
+    {
+        auto old = ConstrainedValue(unsafe, value++);
+        fix();
+        return old;
+    }
+    constexpr auto operator-() const noexcept { return ConstrainedValue(-value); }
+    constexpr auto &operator--() noexcept
+    {
+        --value;
+        fix();
+        return *this;
+    }
+    constexpr auto operator--(int) noexcept
+    {
+        auto old = ConstrainedValue(unsafe, value--);
+        fix();
+        return old;
+    }
+    friend constexpr auto operator+(const ConstrainedValue &lhs, const ConstrainedValue &rhs) noexcept
+    {
+        return ConstrainedValue(lhs.value + rhs.value);
+    }
+    friend constexpr auto operator-(const ConstrainedValue &lhs, const ConstrainedValue &rhs) noexcept
+    {
+        if constexpr (cyclic)
+        {
+            using std::abs;
+            const auto a = lhs.get() - rhs.get();
+            const auto b = (lhs > rhs) ? (a - range_type::cycle) : (a + range_type::cycle);
+            return ConstrainedValue((abs(a) <= abs(b)) ? a : b);
+        }
+        else
+        {
+            return ConstrainedValue(lhs.value - rhs.value);
+        }
+    }
+    friend constexpr auto operator*(const ConstrainedValue &lhs, const ConstrainedValue &rhs) noexcept
+    {
+        return ConstrainedValue(lhs.value * rhs.value);
+    }
+    friend constexpr auto operator/(const ConstrainedValue &lhs, const ConstrainedValue &rhs) noexcept
+    {
+        return ConstrainedValue(lhs.value / rhs.value);
+    }
+
+    constexpr auto &operator+=(const ConstrainedValue &other) noexcept
+    {
+        value += other.value;
+        fix();
+        return *this;
+    }
+    constexpr auto &operator-=(const ConstrainedValue &other) noexcept
+    {
+        value -= other.value;
+        fix();
+        return *this;
+    }
+    constexpr auto &operator*=(const ConstrainedValue &other) noexcept
+    {
+        value *= other.value;
+        fix();
+        return *this;
+    }
+    constexpr auto &operator/=(const ConstrainedValue &other) noexcept
+    {
+        value /= other.value;
+        fix();
+        return *this;
+    }
+
+    constexpr type get() const noexcept { return value; }
+    explicit constexpr operator type() const noexcept { return get(); }
+
+    static constexpr type fix_value(type value) noexcept
+        requires (cyclic)
+    {
+        return range_type::fix_cycle(value);
+    }
+    static constexpr type fix_value(type value) noexcept
+        requires (!cyclic)
+    {
+        return range_type::clamp(value);
+    }
+    constexpr void fix() noexcept { value = fix_value(value); }
+
+    type value;
+};
+
+}  // namespace micromouse
+
+#endif  // MISC_UTILS_VALUE_RANGE_H

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,6 +1,57 @@
-idf_component_register(
-  SRCS
-    "main.cpp"
-  INCLUDE_DIRS
-    "."
-)
+if(CONFIG_MICROMOUSE_UNITTEST_MODE)
+  include(FetchContent)
+  FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG release-1.11.0
+  )
+
+  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+  FetchContent_MakeAvailable(googletest)
+
+  get_property(GTEST_SRCS TARGET gtest PROPERTY SOURCES)
+  get_property(GMOCK_SRCS TARGET gmock PROPERTY SOURCES)
+  get_property(GTEST_SRC_DIR TARGET gtest PROPERTY SOURCE_DIR)
+  get_property(GMOCK_SRC_DIR TARGET gmock PROPERTY SOURCE_DIR)
+  list(TRANSFORM GTEST_SRCS PREPEND ${GTEST_SRC_DIR}/)
+  list(TRANSFORM GMOCK_SRCS PREPEND ${GMOCK_SRC_DIR}/)
+
+  set(GTEST_GMOCK_INCLUDES)
+  foreach(src_dir IN ITEMS ${GTEST_SRC_DIR} ${GMOCK_SRC_DIR})
+    foreach(include_subdir IN ITEMS "" include/)
+      file(RELATIVE_PATH rel_include ${CMAKE_CURRENT_SOURCE_DIR} ${src_dir}/${include_subdir})
+      list(APPEND GTEST_GMOCK_INCLUDES ${rel_include})
+    endforeach()
+  endforeach()
+
+  idf_component_register(
+    SRCS
+      ${GTEST_SRCS}
+      ${GMOCK_SRCS}
+
+      unittests/strongly_typed_test.cc
+      unittests/typing_utils_test.cc
+      unittests/value_range_test.cc
+
+      unittests/direction_test.cc
+
+      unittests/test_main.cc
+    INCLUDE_DIRS
+      ${GTEST_GMOCK_INCLUDES}
+      unittests
+  )
+elseif(MICROMOUSE_MORSE_MODE)
+  idf_component_register(
+    SRCS
+      main.cpp
+    INCLUDE_DIRS
+      .
+  )
+else()
+  idf_component_register(
+    SRCS
+      main.cpp
+    INCLUDE_DIRS
+      .
+  )
+endif()

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -46,4 +46,10 @@ menu "Micromouse Configuration"
         help
             Define the blinking pattern.
 
+    config MICROMOUSE_UNITTEST_MODE
+        bool "Build unittests instead of the main app"
+        default false
+        help
+            Select running mode.
+
 endmenu

--- a/main/unittests/a.h
+++ b/main/unittests/a.h
@@ -1,0 +1,34 @@
+#ifndef UNITTESTS_A_H
+#define UNITTESTS_A_H
+
+#include <compare>
+#include <ostream>
+
+namespace micromouse::tests
+{
+
+struct A
+{
+    A operator+() const noexcept;
+    A &operator++() noexcept;
+    A operator++(int) const noexcept;
+    A operator-() const noexcept;
+    A &operator--() noexcept;
+    A operator--(int) const noexcept;
+    friend A operator+(const A &, const A &) noexcept;
+    friend A operator-(const A &, const A &) noexcept;
+    friend A operator*(const A &, const A &) noexcept;
+    friend A operator/(const A &, const A &) noexcept;
+    A &operator+=(const A &) noexcept;
+    A &operator-=(const A &) noexcept;
+    A &operator*=(const A &) noexcept;
+    A &operator/=(const A &) noexcept;
+    friend auto operator<=>(const A &, const A &) noexcept = default;
+    friend bool operator==(const A &, const A &) noexcept = default;
+
+    friend std::ostream &operator<<(std::ostream &os, const A &) { return os << 'A'; }
+};
+
+}  // namespace micromouse::tests
+
+#endif  // UNITTESTS_A_H

--- a/main/unittests/direction_test.cc
+++ b/main/unittests/direction_test.cc
@@ -1,0 +1,115 @@
+#include "maze_solver/direction.h"
+
+#include <misc_utils/angle.h>
+
+#include "direction_utils.h"
+
+#include <gtest/gtest.h>
+
+#include <numbers>
+#include <type_traits>
+#include <unordered_set>
+
+#include <hack.h>
+
+namespace micromouse::tests
+{
+
+TEST(RelativeDirectionTest, Invert)
+{
+    EXPECT_EQ(invert(RelativeDirection::Front), RelativeDirection::Back);
+    EXPECT_EQ(invert(RelativeDirection::Back), RelativeDirection::Front);
+    EXPECT_EQ(invert(RelativeDirection::Left), RelativeDirection::Right);
+    EXPECT_EQ(invert(RelativeDirection::Right), RelativeDirection::Left);
+
+    for (auto rd : relative_directions)
+    {
+        EXPECT_EQ(invert(invert(rd)), rd);
+    }
+}
+
+TEST(RelativeDirectionTest, ToString)
+{
+    EXPECT_EQ(enum2str(RelativeDirection::Front), "Front");
+    EXPECT_EQ(enum2str(RelativeDirection::Back), "Back");
+    EXPECT_EQ(enum2str(RelativeDirection::Left), "Left");
+    EXPECT_EQ(enum2str(RelativeDirection::Right), "Right");
+}
+
+template <unsigned Turns, Direction (*TurnFunc)(Direction)>
+    requires (Turns > 0)
+void test_turn_cycle_impl()
+{
+    std::unordered_set<Direction> seen;
+    seen.reserve(std::extent_v<decltype(primary_directions)>);
+    for (auto d : primary_directions)
+    {
+        seen.clear();
+        auto curr = d;
+        for (unsigned i = 0; i < Turns; ++i)
+        {
+            ASSERT_TRUE(seen.insert(curr).second) << "cycle ended too early (after " << i << " steps, expected "
+                                                  << Turns << ", started at " << d << " and got to " << curr << ")";
+            curr = TurnFunc(curr);
+        }
+        ASSERT_EQ(curr, d) << "cycle didn't end after " << Turns << " steps (started at " << d << " and got to " << curr
+                           << ")";
+        ASSERT_EQ(seen.size(), Turns) << "not enough unique steps";
+    }
+}
+
+TEST(DirectionTest, TurnCycle)
+{
+    test_turn_cycle_impl<2, turn_back>();
+    test_turn_cycle_impl<4, turn_left>();
+    test_turn_cycle_impl<4, turn_right>();
+}
+
+TEST(DirectionTest, TurnRel)
+{
+    for (auto d : primary_directions)
+    {
+        EXPECT_EQ(turn(d, RelativeDirection::Front), d);
+        EXPECT_EQ(turn(d, RelativeDirection::Back), turn_back(d));
+        EXPECT_EQ(turn(d, RelativeDirection::Left), turn_left(d));
+        EXPECT_EQ(turn(d, RelativeDirection::Right), turn_right(d));
+    }
+}
+
+TEST(DirectionTest, ToDegrees)
+{
+    EXPECT_EQ(to_degrees(Direction::North), -90);
+    EXPECT_EQ(to_degrees(Direction::East), 0);
+    EXPECT_EQ(to_degrees(Direction::South), 90);
+    EXPECT_EQ(to_degrees(Direction::West), -180);
+}
+
+TEST(DirectionTest, ToRadians)
+{
+    EXPECT_FLOAT_EQ(to_radians(Direction::North), -std::numbers::pi_v<float> / 2);
+    EXPECT_FLOAT_EQ(to_radians(Direction::East), 0.0f);
+    EXPECT_FLOAT_EQ(to_radians(Direction::South), std::numbers::pi_v<float> / 2);
+    EXPECT_FLOAT_EQ(to_radians(Direction::West), -std::numbers::pi_v<float>);
+
+    EXPECT_DOUBLE_EQ(to_radians<double>(Direction::North), -std::numbers::pi / 2);
+    EXPECT_DOUBLE_EQ(to_radians<double>(Direction::East), 0.0);
+    EXPECT_DOUBLE_EQ(to_radians<double>(Direction::South), std::numbers::pi / 2);
+    EXPECT_DOUBLE_EQ(to_radians<double>(Direction::West), -std::numbers::pi);
+
+    EXPECT_FLOAT_EQ(to_radians<Angle>(Direction::North).get(), -std::numbers::pi_v<float> / 2);
+    EXPECT_FLOAT_EQ(to_radians<Angle>(Direction::East).get(), 0.0f);
+    EXPECT_FLOAT_EQ(to_radians<Angle>(Direction::South).get(), std::numbers::pi_v<float> / 2);
+    EXPECT_FLOAT_EQ(to_radians<Angle>(Direction::West).get(), -std::numbers::pi_v<float>);
+}
+
+TEST(DirectionTest, ToString)
+{
+    EXPECT_EQ(enum2str(Direction::North), "North");
+    EXPECT_EQ(enum2str(Direction::East), "East");
+    EXPECT_EQ(enum2str(Direction::South), "South");
+    EXPECT_EQ(enum2str(Direction::West), "West");
+}
+
+}  // namespace micromouse::tests
+
+REGISTER_TEST_FILE(direction_tests);

--- a/main/unittests/direction_utils.h
+++ b/main/unittests/direction_utils.h
@@ -1,0 +1,23 @@
+#ifndef UNITTESTS_DIRECTION_UTILS_H
+#define UNITTESTS_DIRECTION_UTILS_H
+
+#include <maze_solver/direction.h>
+
+#include <ostream>
+
+namespace micromouse
+{
+
+std::ostream &operator<<(std::ostream &os, RelativeDirection rd)
+{
+    return os << enum2str(rd);
+}
+
+std::ostream &operator<<(std::ostream &os, Direction d)
+{
+    return os << enum2str(d);
+}
+
+}  // namespace micromouse
+
+#endif  // UNITTESTS_DIRECTION_UTILS_H

--- a/main/unittests/hack.h
+++ b/main/unittests/hack.h
@@ -1,0 +1,10 @@
+#ifndef UNITTESTS_HACK_H
+#define UNITTESTS_HACK_H
+
+#define REGISTER_TEST_FILE(ident) int ident = 0
+
+#define LOAD_TEST_FILE(ident)                                                                                          \
+    extern int ident;                                                                                                  \
+    [[maybe_unused]] static int use_##ident = ident
+
+#endif  // UNITTESTS_HACK_H

--- a/main/unittests/strongly_typed_test.cc
+++ b/main/unittests/strongly_typed_test.cc
@@ -1,0 +1,227 @@
+#include "misc_utils/strongly_typed.h"
+
+#include <misc_utils/angle.h>
+#include <misc_utils/typing_utils.h>
+
+#include "a.h"
+#include "strongly_typed_utils.h"
+#include "type_list.h"
+
+#include <gtest/gtest.h>
+
+#include <concepts>
+#include <type_traits>
+
+#include <hack.h>
+
+namespace micromouse::tests
+{
+
+using SimpleStrongInt = StronglyTyped<int>;
+using VeryStrongInt = StronglyTyped<SimpleStrongInt>;
+using StrongBool = StronglyTyped<bool>;
+using StrongA = StronglyTyped<A>;
+
+struct custom_tag;
+using TaggedStrongInt = StronglyTyped<int, custom_tag>;
+
+struct CustomStrongInt : StronglyTypedBase<int, CustomStrongInt>
+{
+    using StronglyTypedBase<int, CustomStrongInt>::StronglyTypedBase;
+};
+
+static_assert(!std::is_same_v<StronglyTyped<int>, StronglyTyped<int>>, "Bad automatic tagging");
+static_assert(!std::is_same_v<SimpleStrongInt, StronglyTyped<int>>, "Bad automatic tagging");
+static_assert(std::is_same_v<SimpleStrongInt, SimpleStrongInt>, "Bad automatic tagging");
+
+static_assert(std::is_same_v<StronglyTyped<int, custom_tag>, StronglyTyped<int, custom_tag>>, "Bad manual tagging");
+static_assert(std::is_same_v<TaggedStrongInt, StronglyTyped<int, custom_tag>>, "Bad manual tagging");
+static_assert(std::is_same_v<TaggedStrongInt, TaggedStrongInt>, "Bad manual tagging");
+
+static_assert(!std::is_same_v<SimpleStrongInt, CustomStrongInt>, "Bad tagging");
+static_assert(!std::is_same_v<SimpleStrongInt, TaggedStrongInt>, "Bad tagging");
+static_assert(!std::is_same_v<CustomStrongInt, TaggedStrongInt>, "Bad tagging");
+
+static_assert(is_strongly_typed_v<SimpleStrongInt>, "Trait missed a strong type");
+static_assert(is_strongly_typed_v<TaggedStrongInt>, "Trait missed a strong type");
+static_assert(is_strongly_typed_v<CustomStrongInt>, "Trait missed a strong type");
+static_assert(is_strongly_typed_v<VeryStrongInt>, "Trait missed a strong type");
+static_assert(is_strongly_typed_v<StrongBool>, "Trait missed a strong type");
+static_assert(is_strongly_typed_v<StrongA>, "Trait missed a strong type");
+static_assert(!is_strongly_typed_v<int>, "Trait detected a weak type as strong");
+static_assert(!is_strongly_typed_v<float>, "Trait detected a weak type as strong");
+static_assert(!is_strongly_typed_v<A>, "Trait detected a weak type as strong");
+
+static_assert(StrongType<SimpleStrongInt>, "Concept missed a strong type");
+static_assert(StrongType<TaggedStrongInt>, "Concept missed a strong type");
+static_assert(StrongType<CustomStrongInt>, "Concept missed a strong type");
+static_assert(StrongType<VeryStrongInt>, "Concept missed a strong type");
+static_assert(StrongType<StrongBool>, "Concept missed a strong type");
+static_assert(StrongType<StrongA>, "Concept missed a strong type");
+static_assert(!StrongType<int>, "Concept detected a weak type as strong");
+static_assert(!StrongType<float>, "Concept detected a weak type as strong");
+static_assert(!StrongType<A>, "Concept detected a weak type as strong");
+
+template <typename From, typename To>
+struct is_only_explicitly_convertible_to
+    : std::conjunction<std::negation<std::is_convertible<From, To>>, std::is_constructible<To, From>>
+{};
+
+template <typename T, typename U>
+struct mutually_explicitly_convertible
+    : std::conjunction<is_only_explicitly_convertible_to<T, U>, is_only_explicitly_convertible_to<U, T>>
+{};
+
+static_assert(mutually_explicitly_convertible<SimpleStrongInt, int>::value);
+static_assert(mutually_explicitly_convertible<TaggedStrongInt, int>::value);
+static_assert(mutually_explicitly_convertible<CustomStrongInt, int>::value);
+static_assert(mutually_explicitly_convertible<VeryStrongInt, int>::value);
+static_assert(mutually_explicitly_convertible<VeryStrongInt, SimpleStrongInt>::value);
+static_assert(mutually_explicitly_convertible<StrongBool, bool>::value);
+static_assert(mutually_explicitly_convertible<StrongA, A>::value);
+static_assert(mutually_explicitly_convertible<StronglyTyped<float>, float>::value);
+static_assert(mutually_explicitly_convertible<StronglyTyped<float>, int>::value);
+static_assert(!mutually_explicitly_convertible<SimpleStrongInt, A>::value);
+static_assert(!std::is_convertible<SimpleStrongInt, TaggedStrongInt>::value);
+static_assert(!std::is_convertible<TaggedStrongInt, SimpleStrongInt>::value);
+static_assert(!std::is_convertible<VeryStrongInt, TaggedStrongInt>::value);
+static_assert(!std::is_convertible<TaggedStrongInt, VeryStrongInt>::value);
+
+struct IntPoint
+{
+    int x;
+    int y;
+
+    constexpr IntPoint() noexcept = default;
+    constexpr IntPoint(int x_coord, int y_coord) noexcept : x{x_coord}, y{y_coord} {}
+
+    friend constexpr bool operator==(const IntPoint &, const IntPoint &) noexcept = default;
+};
+using StrongPoint = StronglyTyped<IntPoint>;
+
+static_assert(mutually_explicitly_convertible<IntPoint, StrongPoint>::value);
+static_assert(std::is_nothrow_constructible_v<StrongPoint, int, int>);
+
+using BasicAngle = ConstrainedValue<AngleRange>;
+using Angle = StronglyTyped<BasicAngle>;
+struct CrtpAngle : StronglyTypedBase<BasicAngle, CrtpAngle>
+{
+    using StronglyTypedBase<BasicAngle, CrtpAngle>::StronglyTypedBase;
+};
+
+static_assert(!is_strongly_typed_v<BasicAngle>, "Trait detected a weak type as strong");
+static_assert(is_strongly_typed_v<Angle>, "Trait missed a strong type");
+static_assert(is_strongly_typed_v<CrtpAngle>, "Trait missed a strong type");
+
+static_assert(!StrongType<BasicAngle>, "Concept detected a weak type as strong");
+static_assert(StrongType<Angle>, "Concept missed a strong type");
+static_assert(StrongType<CrtpAngle>, "Concept missed a strong type");
+
+template <typename T>
+constexpr auto default_value()
+{
+    return T{};
+}
+
+template <typename T>
+constexpr auto some_value()
+{
+    return default_value<A>();
+}
+template <std::integral I>
+auto some_value()
+{
+    return I(42);
+}
+template <std::floating_point F>
+auto some_value()
+{
+    return F(123.45);
+}
+template <>
+auto some_value<BasicAngle>()
+{
+    return BasicAngle{std::numbers::pi_v<BasicAngle::type> / 4};
+}
+
+template <StrongType T>
+class StronglyTypedTestBase : public ::testing::Test
+{
+public:
+    using strong_type = T;
+    using type = T::type;
+};
+
+template <StrongType T>
+using StronglyTypedTest = StronglyTypedTestBase<T>;
+
+template <StrongType T>
+using StronglyTypedArithmeticTest = StronglyTypedTestBase<T>;
+
+using NonArithmeticTypes = TypeList<StrongA, StrongBool>;
+using ArithmeticTypes = TypeList<
+    SimpleStrongInt,
+    StronglyTyped<float>,
+    StronglyTyped<long>,
+    StronglyTyped<short>,
+    StronglyTyped<double>,
+    Angle,
+    CrtpAngle>;
+using AllTypes = Join<ArithmeticTypes, NonArithmeticTypes>;
+
+TYPED_TEST_SUITE(StronglyTypedTest, AllTypes::types, );
+TYPED_TEST_SUITE(StronglyTypedArithmeticTest, ArithmeticTypes::types, );
+
+TYPED_TEST(StronglyTypedTest, ConstructAndGet)
+{
+    using type = TestFixture::type;
+    using strong_type = TestFixture::strong_type;
+    static_assert(is_strongly_typed_v<strong_type>);
+
+    type val = some_value<type>();
+    strong_type strong(val);
+    strong_type strong2(default_value<type>());
+    ASSERT_EQ(strong.get(), val);
+    ASSERT_EQ(strong, strong_type{val});
+    ASSERT_EQ(*strong2, default_value<type>());
+    ASSERT_EQ(strong2, strong_type{default_value<type>()});
+    if (default_value<type>() == some_value<type>())
+    {
+        ASSERT_EQ(strong, strong2);
+    }
+    else
+    {
+        ASSERT_NE(strong, strong2);
+    }
+}
+
+TYPED_TEST(StronglyTypedArithmeticTest, SimpleArithmetic)
+{
+    using type = TestFixture::type;
+    using strong_type = TestFixture::strong_type;
+    static_assert(is_strongly_typed_v<strong_type>);
+
+    const auto a = some_value<type>();
+    const auto b = static_cast<type>(a * 2);
+    static_assert(std::is_same_v<decltype(a), const type> && std::is_same_v<decltype(a), const type> && std::is_same_v<decltype(b), const type>);
+
+    const auto sa = strong_type(a);
+    const auto sb = strong_type(b);
+    static_assert(std::is_same_v<decltype(a), const type> && std::is_same_v<decltype(a), const type> && std::is_same_v<decltype(b), const type>);
+
+    static_assert(std::is_same_v<decltype(sb + sa), strong_type>);
+    EXPECT_EQ(b + a, (sb + sa).get());
+
+    static_assert(std::is_same_v<decltype(sb - sa), strong_type>);
+    EXPECT_EQ(b - a, (sb - sa).get());
+
+    static_assert(std::is_same_v<decltype(sb * sa), strong_type>);
+    EXPECT_EQ(b * a, (sb * sa).get());
+
+    static_assert(std::is_same_v<decltype(sb / sa), strong_type>);
+    EXPECT_EQ(b / a, (sb / sa).get());
+}
+
+}  // namespace micromouse::tests
+
+REGISTER_TEST_FILE(strongly_typed_tests);

--- a/main/unittests/strongly_typed_utils.h
+++ b/main/unittests/strongly_typed_utils.h
@@ -1,0 +1,17 @@
+#ifndef UNITTESTS_STRONGLY_TYPED_UTILS_H
+#define UNITTESTS_STRONGLY_TYPED_UTILS_H
+
+#include <misc_utils/strongly_typed.h>
+
+#include <ostream>
+
+namespace micromouse
+{
+template <StrongType T>
+std::ostream &operator<<(std::ostream &os, const T &st)
+{
+    return os << "StronglyTyped{" << st.get() << "}";
+}
+}  // namespace micromouse
+
+#endif  // UNITTESTS_STRONGLY_TYPED_UTILS_H

--- a/main/unittests/test_main.cc
+++ b/main/unittests/test_main.cc
@@ -1,0 +1,479 @@
+/* Blink Example
+
+   This example code is in the Public Domain (or CC0 licensed, at your option.)
+
+   Unless required by applicable law or agreed to in writing, this
+   software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied.
+*/
+#include <misc_utils/angle.h>
+
+#include "sdkconfig.h"
+
+#include <driver/gpio.h>
+#include <esp_log.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <led_strip.h>
+
+#include <gtest/gtest.h>
+
+#include <stdio.h>
+
+#include "hack.h"
+
+LOAD_TEST_FILE(direction_tests);
+LOAD_TEST_FILE(strongly_typed_tests);
+LOAD_TEST_FILE(type_utils_tests);
+LOAD_TEST_FILE(value_range_tests);
+
+void run_tests()
+{
+    int argc = 1;
+    char prog_name[] = "test_image";
+    char color_flag[] = "--gtest_color=yes";
+    char *argv[] = {prog_name, color_flag, nullptr};
+    ESP_LOGI("googletest", "Running gtest...");
+    ::testing::InitGoogleTest(&argc, argv);
+    int retcode = RUN_ALL_TESTS();
+    if (retcode == 0)
+    {
+        ESP_LOGI("googletest", "All tests passed!");
+    }
+    else
+    {
+        ESP_LOGE("googletest", "Error in tests (exitcode: %d)", retcode);
+    }
+}
+
+static const char *TAG = "example";
+
+/* Use project configuration menu (idf.py menuconfig) to choose the GPIO to blink,
+   or you can edit the following line and set a number here.
+*/
+inline constexpr auto blink_gpio = static_cast<gpio_num_t>(CONFIG_BLINK_GPIO);
+
+static uint8_t s_led_state = 0;
+
+#ifdef CONFIG_BLINK_LED_RMT
+
+static led_strip_handle_t led_strip;
+
+static void blink_led(void)
+{
+    /* If the addressable LED is enabled */
+    if (s_led_state)
+    {
+        /* Set the LED pixel using RGB from 0 (0%) to 255 (100%) for each color */
+        led_strip_set_pixel(led_strip, 0, 16, 16, 16);
+        /* Refresh the strip to send data */
+        led_strip_refresh(led_strip);
+    }
+    else
+    {
+        /* Set all LED off to clear all pixels */
+        led_strip_clear(led_strip);
+    }
+}
+
+static void configure_led(void)
+{
+    ESP_LOGI(TAG, "Example configured to blink addressable LED!");
+    /* LED strip initialization with the GPIO and pixels number*/
+    led_strip_config_t strip_config = {
+        .strip_gpio_num = blink_gpio,
+        .max_leds = 1,  // at least one LED on board
+    };
+    led_strip_rmt_config_t rmt_config = {
+        .resolution_hz = 10 * 1'000 * 1'000,  // 10MHz
+    };
+    ESP_ERROR_CHECK(led_strip_new_rmt_device(&strip_config, &rmt_config, &led_strip));
+    /* Set all LED off to clear all pixels */
+    led_strip_clear(led_strip);
+}
+
+#elif CONFIG_BLINK_LED_GPIO
+
+static void blink_led(void)
+{
+    /* Set the GPIO level according to the state (LOW or HIGH)*/
+    gpio_set_level(blink_gpio, s_led_state);
+}
+
+static void configure_led(void)
+{
+    ESP_LOGI(TAG, "Example configured to blink GPIO LED!");
+    gpio_reset_pin(blink_gpio);
+    /* Set the GPIO as a push/pull output */
+    gpio_set_direction(blink_gpio, GPIO_MODE_OUTPUT);
+}
+
+#endif
+
+#if CONFIG_BLINK_PATTERN_MORSE
+
+inline constexpr char text[] = CONFIG_BLINK_PATTERN_MORSE_TEXT;
+
+enum class MorseElement
+{
+    Dot,        // dot/dit - '1'
+    Dash,       // dash/dah - '111'
+    MarkSep,    // intra-character gap (between dits and dahs within a character) - '0'
+    LetterSep,  // gap between characters - '000'
+    WordSep,    // gap between words - '0000000'
+};
+
+constexpr size_t ticks(MorseElement m) noexcept
+{
+    switch (m)
+    {
+    case MorseElement::Dot:
+        return 1;
+    case MorseElement::Dash:
+        return 3;
+    case MorseElement::MarkSep:
+        return 1;
+    case MorseElement::LetterSep:
+        return 3;
+    case MorseElement::WordSep:
+        return 7;
+    }
+
+    return 0;
+}
+
+constexpr uint8_t state(MorseElement m) noexcept
+{
+    switch (m)
+    {
+    case MorseElement::Dot:
+    case MorseElement::Dash:
+        return 1;
+
+    case MorseElement::MarkSep:
+    case MorseElement::LetterSep:
+    case MorseElement::WordSep:
+        return 0;
+    }
+
+    return 0;
+}
+
+struct MorseSymbol
+{
+    static constexpr auto max_elements = 20UZ;
+    MorseElement elements[max_elements];
+    size_t used_elements = 0;
+
+    constexpr auto begin() noexcept { return elements; }
+    constexpr auto begin() const noexcept { return elements; }
+    constexpr auto cbegin() const noexcept { return begin(); }
+
+    constexpr auto end() noexcept { return elements + used_elements; }
+    constexpr auto end() const noexcept { return elements + used_elements; }
+    constexpr auto cend() const noexcept { return end(); }
+
+    constexpr auto size() const noexcept { return used_elements; }
+
+    using value_type = MorseElement;
+    using reference = MorseElement &;
+    using const_reference = const MorseElement &;
+    using pointer = MorseElement *;
+    using const_pointer = const MorseElement *;
+    using iterator = pointer;
+    using const_iterator = const_pointer;
+    using size_type = decltype(MorseSymbol::used_elements);
+
+    constexpr MorseSymbol() noexcept = default;
+
+    template <size_t N>
+        requires (N <= max_elements)
+    constexpr MorseSymbol(const MorseElement (&elems)[N]) noexcept : elements{}
+                                                                   , used_elements(N)
+    {
+        for (auto i = 0ZU; i < N; ++i)
+        {
+            elements[i] = elems[i];
+        }
+    }
+
+    template <size_t N>
+        requires (N * 2 <= max_elements)
+    static constexpr MorseSymbol from_elements(const MorseElement (&elems)[N], bool word_end = false) noexcept
+    {
+        MorseElement expanded[N * 2];
+        for (auto i = 0UZ; i < N; ++i)
+        {
+            const auto ei = i * 2;
+            expanded[ei] = elems[i];
+            expanded[ei + 1] = MorseElement::MarkSep;
+        }
+        expanded[(N * 2) - 1] = word_end ? MorseElement::WordSep : MorseElement::LetterSep;
+        return {expanded};
+    }
+
+    static constexpr MorseSymbol from_char(char c, bool word_end = false) noexcept
+    {
+        // clang-format off
+        switch (c)
+        {
+        case 'a':
+        case 'A':
+            return from_elements({MorseElement::Dot, MorseElement::Dash}, word_end);
+
+        case 'b':
+        case 'B':
+            return from_elements({MorseElement::Dash, MorseElement::Dot, MorseElement::Dot, MorseElement::Dot}, word_end);
+
+        case 'c':
+        case 'C':
+            return from_elements({MorseElement::Dash, MorseElement::Dot, MorseElement::Dash, MorseElement::Dot}, word_end);
+
+        case 'd':
+        case 'D':
+            return from_elements({MorseElement::Dash, MorseElement::Dot, MorseElement::Dot}, word_end);
+
+        case 'e':
+        case 'E':
+            return from_elements({MorseElement::Dot}, word_end);
+
+        case 'f':
+        case 'F':
+            return from_elements({MorseElement::Dot, MorseElement::Dot, MorseElement::Dash, MorseElement::Dot}, word_end);
+
+        case 'g':
+        case 'G':
+            return from_elements({MorseElement::Dash, MorseElement::Dash, MorseElement::Dot}, word_end);
+
+        case 'h':
+        case 'H':
+            return from_elements({MorseElement::Dot, MorseElement::Dot, MorseElement::Dot, MorseElement::Dot}, word_end);
+
+        case 'i':
+        case 'I':
+            return from_elements({MorseElement::Dot, MorseElement::Dot}, word_end);
+
+        case 'j':
+        case 'J':
+            return from_elements({MorseElement::Dot, MorseElement::Dash, MorseElement::Dash, MorseElement::Dash}, word_end);
+
+        case 'k':
+        case 'K':
+            return from_elements({MorseElement::Dash, MorseElement::Dot, MorseElement::Dash}, word_end);
+
+        case 'l':
+        case 'L':
+            return from_elements({MorseElement::Dot, MorseElement::Dash, MorseElement::Dot, MorseElement::Dot}, word_end);
+
+        case 'm':
+        case 'M':
+            return from_elements({MorseElement::Dash, MorseElement::Dash}, word_end);
+
+        case 'n':
+        case 'N':
+            return from_elements({MorseElement::Dash, MorseElement::Dot}, word_end);
+
+        case 'o':
+        case 'O':
+            return from_elements({MorseElement::Dash, MorseElement::Dash, MorseElement::Dash}, word_end);
+
+        case 'p':
+        case 'P':
+            return from_elements({MorseElement::Dot, MorseElement::Dash, MorseElement::Dash, MorseElement::Dot}, word_end);
+
+        case 'q':
+        case 'Q':
+            return from_elements({MorseElement::Dash, MorseElement::Dash, MorseElement::Dot, MorseElement::Dash}, word_end);
+
+        case 'r':
+        case 'R':
+            return from_elements({MorseElement::Dot, MorseElement::Dash, MorseElement::Dot}, word_end);
+
+        case 's':
+        case 'S':
+            return from_elements({MorseElement::Dot, MorseElement::Dot, MorseElement::Dot}, word_end);
+
+        case 't':
+        case 'T':
+            return from_elements({MorseElement::Dash}, word_end);
+
+        case 'u':
+        case 'U':
+            return from_elements({MorseElement::Dot, MorseElement::Dot, MorseElement::Dash}, word_end);
+
+        case 'v':
+        case 'V':
+            return from_elements({MorseElement::Dot, MorseElement::Dot, MorseElement::Dot, MorseElement::Dash}, word_end);
+
+        case 'w':
+        case 'W':
+            return from_elements({MorseElement::Dot, MorseElement::Dash, MorseElement::Dash}, word_end);
+
+        case 'x':
+        case 'X':
+            return from_elements({MorseElement::Dash, MorseElement::Dot, MorseElement::Dot, MorseElement::Dash}, word_end);
+
+        case 'y':
+        case 'Y':
+            return from_elements({MorseElement::Dash, MorseElement::Dot, MorseElement::Dash, MorseElement::Dash}, word_end);
+
+        case 'z':
+        case 'Z':
+            return from_elements({MorseElement::Dash, MorseElement::Dash, MorseElement::Dot, MorseElement::Dot}, word_end);
+
+        case '0':
+            return from_elements({MorseElement::Dash, MorseElement::Dash, MorseElement::Dash, MorseElement::Dash, MorseElement::Dash}, word_end);
+
+        case '1':
+            return from_elements({MorseElement::Dot, MorseElement::Dash, MorseElement::Dash, MorseElement::Dash, MorseElement::Dash}, word_end);
+
+        case '2':
+            return from_elements({MorseElement::Dot, MorseElement::Dot, MorseElement::Dash, MorseElement::Dash, MorseElement::Dash}, word_end);
+
+        case '3':
+            return from_elements({MorseElement::Dot, MorseElement::Dot, MorseElement::Dot, MorseElement::Dash, MorseElement::Dash}, word_end);
+
+        case '4':
+            return from_elements({MorseElement::Dot, MorseElement::Dot, MorseElement::Dot, MorseElement::Dot, MorseElement::Dash}, word_end);
+
+        case '5':
+            return from_elements({MorseElement::Dot, MorseElement::Dot, MorseElement::Dot, MorseElement::Dot, MorseElement::Dot}, word_end);
+
+        case '6':
+            return from_elements({MorseElement::Dash, MorseElement::Dot, MorseElement::Dot, MorseElement::Dot, MorseElement::Dot}, word_end);
+
+        case '7':
+            return from_elements({MorseElement::Dash, MorseElement::Dash, MorseElement::Dot, MorseElement::Dot, MorseElement::Dot}, word_end);
+
+        case '8':
+            return from_elements({MorseElement::Dash, MorseElement::Dash, MorseElement::Dash, MorseElement::Dot, MorseElement::Dot}, word_end);
+
+        case '9':
+            return from_elements({MorseElement::Dash, MorseElement::Dash, MorseElement::Dash, MorseElement::Dash, MorseElement::Dot}, word_end);
+
+        case '.':
+            return from_elements({MorseElement::Dot, MorseElement::Dash, MorseElement::Dot, MorseElement::Dash, MorseElement::Dot, MorseElement::Dash}, word_end);
+
+        case ',':
+            return from_elements({MorseElement::Dash, MorseElement::Dash, MorseElement::Dot, MorseElement::Dot, MorseElement::Dash, MorseElement::Dash}, word_end);
+
+        case '?':
+            return from_elements({MorseElement::Dot, MorseElement::Dot, MorseElement::Dash, MorseElement::Dash, MorseElement::Dot, MorseElement::Dot}, word_end);
+
+        case '\'':
+            return from_elements({MorseElement::Dot, MorseElement::Dash, MorseElement::Dash, MorseElement::Dash, MorseElement::Dash, MorseElement::Dot}, word_end);
+
+        case '!':
+            return from_elements({MorseElement::Dash, MorseElement::Dot, MorseElement::Dash, MorseElement::Dot, MorseElement::Dash, MorseElement::Dash}, word_end);
+
+        case '/':
+            return from_elements({MorseElement::Dash, MorseElement::Dot, MorseElement::Dot, MorseElement::Dash, MorseElement::Dot}, word_end);
+
+        case '(':
+            return from_elements({MorseElement::Dash, MorseElement::Dot, MorseElement::Dash, MorseElement::Dash, MorseElement::Dot}, word_end);
+
+        case ')':
+            return from_elements({MorseElement::Dash, MorseElement::Dot, MorseElement::Dash, MorseElement::Dash, MorseElement::Dot, MorseElement::Dash}, word_end);
+
+        case '&':
+            return from_elements({MorseElement::Dot, MorseElement::Dash, MorseElement::Dot, MorseElement::Dot, MorseElement::Dot}, word_end);
+
+        case ':':
+            return from_elements({MorseElement::Dash, MorseElement::Dash, MorseElement::Dash, MorseElement::Dot, MorseElement::Dot, MorseElement::Dot}, word_end);
+
+        case ';':
+            return from_elements({MorseElement::Dash, MorseElement::Dot, MorseElement::Dash, MorseElement::Dot, MorseElement::Dash, MorseElement::Dot}, word_end);
+
+        case '=':
+            return from_elements({MorseElement::Dash, MorseElement::Dot, MorseElement::Dot, MorseElement::Dot, MorseElement::Dash}, word_end);
+
+        case '+':
+            return from_elements({MorseElement::Dot, MorseElement::Dash, MorseElement::Dot, MorseElement::Dash, MorseElement::Dot}, word_end);
+
+        case '-':
+            return from_elements({MorseElement::Dash, MorseElement::Dot, MorseElement::Dot, MorseElement::Dot, MorseElement::Dot, MorseElement::Dash}, word_end);
+
+        case '_':
+            return from_elements({MorseElement::Dot, MorseElement::Dot, MorseElement::Dash, MorseElement::Dash, MorseElement::Dot, MorseElement::Dash}, word_end);
+
+        case '"':
+            return from_elements({MorseElement::Dot, MorseElement::Dash, MorseElement::Dot, MorseElement::Dot, MorseElement::Dash, MorseElement::Dot}, word_end);
+
+        case '$':
+            return from_elements({MorseElement::Dot, MorseElement::Dot, MorseElement::Dot, MorseElement::Dash, MorseElement::Dot, MorseElement::Dot, MorseElement::Dash}, word_end);
+
+        case '@':
+            return from_elements({MorseElement::Dot, MorseElement::Dash, MorseElement::Dash, MorseElement::Dot, MorseElement::Dash, MorseElement::Dot}, word_end);
+
+        default:
+            return {{MorseElement::MarkSep}};  // PH error
+        }
+        // clang-format on
+    }
+};
+
+constexpr bool is_word_end(char c)
+{
+    switch (c)
+    {
+    case ' ':
+    case '\n':
+    case '\r':
+    case '\t':
+    case '\v':
+    case '\0':
+        return true;
+
+    default:
+        return false;
+    }
+}
+
+[[noreturn]]
+void morse_loop()
+{
+    run_tests();
+    auto pos = text;
+    static constexpr TickType_t delay = CONFIG_BLINK_PERIOD / portTICK_PERIOD_MS;
+
+    while (true)
+    {
+        ESP_LOGI("morse", "Showing character: '%c' (%d, 0x%02X)", *pos, +*pos, +*pos);
+        auto morse = MorseSymbol::from_char(*pos, is_word_end(*(pos + 1)));
+        for (auto elem : morse)
+        {
+            s_led_state = state(elem);
+            ESP_LOGI("morse", "Turning the LED %s!", s_led_state ? "ON" : "OFF");
+            blink_led();
+            vTaskDelay(delay * ticks(elem));
+        }
+
+        // Next char, infinite cycle
+        if (*++pos == '\0')
+        {
+            run_tests();
+            pos = text;
+        }
+    }
+}
+#endif
+
+extern "C" void app_main(void)
+{
+    /* Configure the peripheral according to the LED type */
+    configure_led();
+
+#if CONFIG_BLINK_PATTERN_MORSE
+    morse_loop();
+#else
+    run_tests();
+    while (true)
+    {
+        ESP_LOGI(TAG, "Turning the LED %s!", s_led_state ? "ON" : "OFF");
+        blink_led();
+        /* Toggle the LED state */
+        s_led_state = !s_led_state;
+        vTaskDelay(CONFIG_BLINK_PERIOD / portTICK_PERIOD_MS);
+    }
+#endif
+}

--- a/main/unittests/type_list.h
+++ b/main/unittests/type_list.h
@@ -1,0 +1,122 @@
+#ifndef UNITTEST_TYPE_LIST_H
+#define UNITTEST_TYPE_LIST_H
+
+#include <gtest/gtest.h>  // for ::testing::Types<...>
+
+#include <type_traits>
+
+namespace micromouse::tests
+{
+
+// TypeList - A list of types
+template <typename... Ts>
+struct TypeList
+{
+    using types = ::testing::Types<Ts...>;
+};
+
+template <typename T>
+struct is_type_list : std::false_type
+{};
+
+template <typename... Ts>
+struct is_type_list<TypeList<Ts...>> : std::true_type
+{};
+
+template <typename T>
+inline constexpr auto is_type_list_v = is_type_list<T>::value;
+
+template <typename T>
+concept TypeListType = is_type_list_v<T>;
+
+template <typename T>
+concept TypeListManipulator = TypeListType<typename T::as_list>;
+
+template <typename T>
+concept ExtendedTypeList = TypeListType<T> || TypeListManipulator<T>;
+
+static_assert(ExtendedTypeList<TypeList<int, float>>);
+static_assert(TypeListType<TypeList<int, float>>);
+static_assert(!TypeListManipulator<TypeList<int, float>>);
+
+// Join - Concatenates `TypeList`s (or manipulators)
+template <ExtendedTypeList, ExtendedTypeList>
+struct Join;
+
+template <TypeListManipulator Lhs, TypeListManipulator Rhs>
+struct Join<Lhs, Rhs> : Join<typename Lhs::as_list, typename Rhs::as_list>
+{};
+
+template <TypeListType Lhs, TypeListManipulator Rhs>
+struct Join<Lhs, Rhs> : Join<Lhs, typename Rhs::as_list>
+{};
+
+template <TypeListManipulator Lhs, TypeListType Rhs>
+struct Join<Lhs, Rhs> : Join<typename Lhs::as_list, Rhs>
+{};
+
+template <typename... Ts, typename... Us>
+struct Join<TypeList<Ts...>, TypeList<Us...>>
+{
+    using as_list = TypeList<Ts..., Us...>;
+    using types = typename as_list::types;
+};
+
+static_assert(ExtendedTypeList<Join<TypeList<int, float>, TypeList<bool>>>);
+static_assert(!TypeListType<Join<TypeList<int, float>, TypeList<bool>>>);
+static_assert(TypeListManipulator<Join<TypeList<int, float>, TypeList<bool>>>);
+static_assert(std::is_same_v<typename Join<TypeList<int, float>, TypeList<bool>>::as_list, TypeList<int, float, bool>>);
+
+// Apply - Apply a manipulator on a type, works for both `std::add_const` and `std::add_const_t`
+template <template <typename> class Operation, typename Type>
+struct Apply
+{
+    template <typename T, typename = void>
+    struct Helper
+    {
+        using type = T;
+    };
+
+    template <typename T>
+    struct Helper<T, std::void_t<typename T::type>>
+    {
+        using type = typename T::type;
+    };
+
+    using type = typename Helper<Operation<Type>>::type;
+};
+
+template <template <typename> class Operation, typename T>
+using ApplyType = typename Apply<Operation, T>::type;
+
+// Transform - Apply a manipulator on a `TypeList`
+template <ExtendedTypeList, template <typename> class>
+struct Transform;
+
+template <TypeListManipulator List, template <typename> class Operation>
+struct Transform<List, Operation> : Transform<typename List::as_list, Operation>
+{};
+
+template <typename... Ts, template <typename> class Operation>
+struct Transform<TypeList<Ts...>, Operation>
+{
+    using as_list = TypeList<ApplyType<Operation, Ts>...>;
+    using types = typename as_list::types;
+};
+
+static_assert(ExtendedTypeList<Transform<TypeList<int, float>, std::add_const>>);
+static_assert(!TypeListType<Transform<TypeList<int, float>, std::add_const>>);
+static_assert(TypeListManipulator<Transform<TypeList<int, float>, std::add_const>>);
+static_assert(std::is_same_v<
+              typename Transform<TypeList<int, float>, std::add_const>::as_list,
+              TypeList<const int, const float>>);
+
+static_assert(ExtendedTypeList<Transform<TypeList<int, float>, std::add_const_t>>);
+static_assert(!TypeListType<Transform<TypeList<int, float>, std::add_const_t>>);
+static_assert(TypeListManipulator<Transform<TypeList<int, float>, std::add_const_t>>);
+static_assert(std::is_same_v<
+              typename Transform<TypeList<int, float>, std::add_const_t>::as_list,
+              TypeList<const int, const float>>);
+}  // namespace micromouse::tests
+
+#endif  // UNITTEST_TYPE_LIST_H

--- a/main/unittests/typing_utils_test.cc
+++ b/main/unittests/typing_utils_test.cc
@@ -1,0 +1,88 @@
+#include "misc_utils/typing_utils.h"
+
+#include <misc_utils/angle.h>
+#include <misc_utils/strongly_typed.h>
+
+#include "a.h"
+#include "strongly_typed_utils.h"
+
+#include <gtest/gtest.h>
+
+#include <hack.h>
+
+namespace micromouse::tests
+{
+
+using StrongInt = StronglyTyped<int>;
+using StrongBool = StronglyTyped<bool>;
+using StrongA = StronglyTyped<A>;
+
+static_assert(detail::PartialArithmeticHelper<A>);
+static_assert(detail::PartialArithmeticHelper<StrongInt>);
+static_assert(std::is_same_v<decltype(!std::declval<StrongBool>()), StrongBool>);
+static_assert(std::is_same_v<decltype(!std::declval<StrongInt>()), bool>);
+static_assert(detail::PartialArithmeticHelper<StrongA>);
+static_assert(detail::PartialArithmeticHelper<char>);
+static_assert(detail::PartialArithmeticHelper<signed char>);
+static_assert(detail::PartialArithmeticHelper<short>);
+static_assert(detail::PartialArithmeticHelper<int>);
+static_assert(detail::PartialArithmeticHelper<long>);
+static_assert(detail::PartialArithmeticHelper<long long>);
+static_assert(detail::PartialArithmeticHelper<unsigned char>);
+static_assert(detail::PartialArithmeticHelper<unsigned short>);
+static_assert(detail::PartialArithmeticHelper<unsigned int>);
+static_assert(detail::PartialArithmeticHelper<unsigned long>);
+static_assert(detail::PartialArithmeticHelper<unsigned long long>);
+static_assert(detail::PartialArithmeticHelper<float>);
+static_assert(detail::PartialArithmeticHelper<double>);
+static_assert(detail::PartialArithmeticHelper<long double>);
+static_assert(PartialArithmetic<A>);
+static_assert(PartialArithmetic<StrongInt>);
+static_assert(PartialArithmetic<StrongA>);
+static_assert(PartialArithmetic<char>);
+static_assert(PartialArithmetic<signed char>);
+static_assert(PartialArithmetic<short>);
+static_assert(PartialArithmetic<int>);
+static_assert(PartialArithmetic<long>);
+static_assert(PartialArithmetic<long long>);
+static_assert(PartialArithmetic<unsigned char>);
+static_assert(PartialArithmetic<unsigned short>);
+static_assert(PartialArithmetic<unsigned int>);
+static_assert(PartialArithmetic<unsigned long>);
+static_assert(PartialArithmetic<unsigned long long>);
+static_assert(PartialArithmetic<float>);
+static_assert(PartialArithmetic<double>);
+static_assert(PartialArithmetic<long double>);
+
+struct B
+{
+    B operator+() const;
+    B &operator++();
+    B operator++(int) const;
+    B operator-() const;
+    B &operator--();
+    B operator--(int) const;
+    friend B operator+(const B &, const B &);
+    friend B operator-(const B &, const B &);
+    friend B operator*(const B &, const B &);
+    friend B operator/(const B &, const B &);
+    B &operator+=(const B &);
+    B &operator-=(const B &);
+    B &operator*=(const B &);
+    B &operator/=(const B &);
+    friend auto operator<=>(const B &, const B &) = default;
+    friend bool operator==(const B &, const B &) = default;
+};
+
+static_assert(!PartialArithmetic<const char *>);
+static_assert(!PartialArithmetic<B>, "B isn't a PartialArithmetic because it has throwing operators");
+
+static_assert(std::is_same_v<make_floating_point<float>, float>);
+static_assert(std::is_same_v<make_floating_point<double>, double>);
+static_assert(std::is_same_v<make_floating_point<long double>, long double>);
+static_assert(std::is_same_v<make_floating_point<Angle>, Angle::type>);
+static_assert(std::is_same_v<make_floating_point<StronglyTyped<Angle>>, Angle::type>);
+
+}  // namespace micromouse::tests
+
+REGISTER_TEST_FILE(type_utils_tests);

--- a/main/unittests/value_range_test.cc
+++ b/main/unittests/value_range_test.cc
@@ -1,0 +1,168 @@
+#include "misc_utils/value_range.h"
+
+#include <misc_utils/angle.h>
+
+#include "strongly_typed_utils.h"
+#include "type_list.h"
+#include "value_range_utils.h"
+#include "values.h"
+
+#include <gtest/gtest.h>
+
+#include <concepts>
+
+#include <hack.h>
+
+namespace micromouse::tests
+{
+
+template <PartialArithmetic T, T Low, T High>
+struct ValueRangeParams;
+
+template <typename>
+struct ValueRangeTest;
+
+template <PartialArithmetic T, T Low, T High>
+class ValueRangeTest<ValueRangeParams<T, Low, High>> : public ::testing::Test
+{
+public:
+    using type = T;
+    static constexpr T low = Low;
+    static constexpr T high = High;
+
+    void SetUp() override
+    {
+        std::cout << "low = " << low << " | high = " << high
+                  << " | floating point: " << (ExtendedFloatingPoint<T> ? "yes" : "no") << std::endl;
+    }
+};
+
+using AngleRange2 = FloatingAngleRange<0.0f>;
+
+using ValueRangeTypes = TypeList<
+    ValueRangeParams<int, -10, 10>,
+    ValueRangeParams<int, 5, 32>,
+    ValueRangeParams<unsigned, 0, 100>,
+    ValueRangeParams<unsigned, 5, 32>,
+    ValueRangeParams<float, -10.0f, 10.0f>,
+    ValueRangeParams<float, 10.0f, 75.43f>,
+    ValueRangeParams<AngleRange::type, AngleRange::low, AngleRange::high>,
+    ValueRangeParams<AngleRange2::type, AngleRange2::low, AngleRange2::high>>;
+
+TYPED_TEST_SUITE(ValueRangeTest, ValueRangeTypes::types, );
+
+template <PartialArithmetic T, T Low, T High, Mode M>
+void value_range_test_impl()
+{
+    using range_type = ValueRange<T, Low, High, M>;
+    using cv_cycle = ConstrainedValue<range_type, true>;
+    using cv_clamp = ConstrainedValue<range_type, false>;
+
+    static_assert(range_type::clamp_epsilon > T{});
+    static_assert(!std::integral<T> || range_type::clamp_epsilon == 1);
+
+    std::cout << "mode = " << M << std::endl;
+
+    static_assert(range_type::contains(range_type::low) == !range_type::is_left_open);
+    static_assert(range_type::contains(range_type::high) == !range_type::is_right_open);
+
+    for (auto value : values_helper<T>::values)
+    {
+        EXPECT_GE(range_type::clamp(value), range_type::low);
+        EXPECT_GE(range_type::fix_cycle(value), range_type::low);
+
+        EXPECT_LE(range_type::clamp(value), range_type::high);
+        EXPECT_LE(range_type::fix_cycle(value), range_type::high);
+
+        EXPECT_EQ(cv_cycle(value).get(), range_type::fix_cycle(value));
+        EXPECT_EQ(cv_clamp(value).get(), range_type::clamp(value));
+    }
+}
+
+TYPED_TEST(ValueRangeTest, OpenRange)
+{
+    using type = TestFixture::type;
+    using range_type = ValueRange<type, TestFixture::low, TestFixture::high, Mode::Open>;
+    static_assert(std::is_same_v<typename range_type::type, type>);
+    static_assert(range_type::low == TestFixture::low);
+    static_assert(range_type::high == TestFixture::high);
+    static_assert(range_type::mode == Mode::Open);
+    static_assert(range_type::is_open);
+    static_assert(range_type::is_left_open);
+    static_assert(range_type::is_right_open);
+    static_assert(!range_type::is_closed);
+
+    value_range_test_impl<type, range_type::low, range_type::high, range_type::mode>();
+}
+
+TYPED_TEST(ValueRangeTest, ClosedRange)
+{
+    using type = TestFixture::type;
+    using range_type = ValueRange<type, TestFixture::low, TestFixture::high, Mode::Closed>;
+    static_assert(std::is_same_v<typename range_type::type, type>);
+    static_assert(range_type::low == TestFixture::low);
+    static_assert(range_type::high == TestFixture::high);
+    static_assert(range_type::mode == Mode::Closed);
+    static_assert(!range_type::is_open);
+    static_assert(!range_type::is_left_open);
+    static_assert(!range_type::is_right_open);
+    static_assert(range_type::is_closed);
+
+    value_range_test_impl<type, range_type::low, range_type::high, range_type::mode>();
+}
+
+TYPED_TEST(ValueRangeTest, LeftOpenRange)
+{
+    using type = TestFixture::type;
+    using range_type = ValueRange<type, TestFixture::low, TestFixture::high, Mode::LeftOpen>;
+    static_assert(std::is_same_v<typename range_type::type, type>);
+    static_assert(range_type::low == TestFixture::low);
+    static_assert(range_type::high == TestFixture::high);
+    static_assert(range_type::mode == Mode::LeftOpen);
+    static_assert(!range_type::is_open);
+    static_assert(range_type::is_left_open);
+    static_assert(!range_type::is_right_open);
+    static_assert(!range_type::is_closed);
+
+    value_range_test_impl<type, range_type::low, range_type::high, range_type::mode>();
+}
+
+TYPED_TEST(ValueRangeTest, RightOpenRange)
+{
+    using type = TestFixture::type;
+    using range_type = ValueRange<type, TestFixture::low, TestFixture::high, Mode::RightOpen>;
+    static_assert(std::is_same_v<typename range_type::type, type>);
+    static_assert(range_type::low == TestFixture::low);
+    static_assert(range_type::high == TestFixture::high);
+    static_assert(range_type::mode == Mode::RightOpen);
+    static_assert(!range_type::is_open);
+    static_assert(!range_type::is_left_open);
+    static_assert(range_type::is_right_open);
+    static_assert(!range_type::is_closed);
+
+    value_range_test_impl<type, range_type::low, range_type::high, range_type::mode>();
+}
+
+TEST(ValueRangeModeTest, ToString)
+{
+    static_assert(Mode::Closed == Mode::Inclusive);
+    static_assert(Mode::Open == Mode::Exclusive);
+    static_assert(Mode::LeftOpen == Mode::LeftExclusive);
+    static_assert(Mode::LeftOpen == Mode::RightInclusive);
+    static_assert(Mode::RightOpen == Mode::RightExclusive);
+    static_assert(Mode::RightOpen == Mode::LeftInclusive);
+    EXPECT_EQ(enum2str(Mode::Closed), "Closed");
+    EXPECT_EQ(enum2str(Mode::Inclusive), "Closed");
+    EXPECT_EQ(enum2str(Mode::Open), "Open");
+    EXPECT_EQ(enum2str(Mode::Exclusive), "Open");
+    EXPECT_EQ(enum2str(Mode::LeftOpen), "LeftOpen");
+    EXPECT_EQ(enum2str(Mode::LeftExclusive), "LeftOpen");
+    EXPECT_EQ(enum2str(Mode::RightInclusive), "LeftOpen");
+    EXPECT_EQ(enum2str(Mode::RightOpen), "RightOpen");
+    EXPECT_EQ(enum2str(Mode::RightExclusive), "RightOpen");
+    EXPECT_EQ(enum2str(Mode::LeftInclusive), "RightOpen");
+}
+
+}  // namespace micromouse::tests
+
+REGISTER_TEST_FILE(value_range_tests);

--- a/main/unittests/value_range_utils.h
+++ b/main/unittests/value_range_utils.h
@@ -1,0 +1,25 @@
+#ifndef UNITTESTS_VALUE_RANGE_UTILS_H
+#define UNITTESTS_VALUE_RANGE_UTILS_H
+
+#include <misc_utils/value_range.h>
+
+#include <ostream>
+
+namespace micromouse
+{
+
+std::ostream &operator<<(std::ostream &os, Mode mode)
+{
+    return os << enum2str(mode);
+}
+
+template <typename R, bool C>
+std::ostream &operator<<(std::ostream &os, const ConstrainedValue<R, C> &st)
+{
+    return os << "ConstrainedValue<low = " << R::low << ", high = " << R::high << ", mode = " << R::mode
+              << ", cycle = " << std::boolalpha << C << ">{" << st.get() << "}";
+}
+
+}  // namespace micromouse
+
+#endif  // UNITTESTS_VALUE_RANGE_UTILS_H

--- a/main/unittests/values.h
+++ b/main/unittests/values.h
@@ -1,0 +1,67 @@
+#ifndef UNITTESTS_VALUES_H
+#define UNITTESTS_VALUES_H
+
+#include <concepts>
+#include <numbers>
+
+namespace micromouse::tests
+{
+
+template <ExtendedArithmetic>
+struct values_helper;
+
+template <ArithmeticWrapper T>
+struct values_helper<T> : values_helper<typename T::type>
+{};
+
+template <std::signed_integral T>
+struct values_helper<T>
+{
+    static constexpr T values[] = {-128, -100, -56, -10, -5, -2, -1, 0, 1, 2, 5, 10, 16, 78, 127};
+};
+
+template <std::unsigned_integral T>
+struct values_helper<T>
+{
+    static constexpr T values[] = {0, 1, 2, 5, 10, 16, 56, 78, 100, 127, 141, 160, 191, 200, 226, 255};
+};
+
+template <>
+struct values_helper<bool>
+{
+    static constexpr bool values[] = {false, true};
+};
+
+template <std::floating_point T>
+struct values_helper<T>
+{
+    static constexpr T values[] = {
+        -128,
+        -100,
+        -56,
+        -10,
+        -std::numbers::pi_v<T>,
+        -std::numbers::e_v<T>,
+        -2,
+        -std::numbers::pi_v<T> / 2,
+        -1,
+        -std::numbers::pi_v<T> / 4,
+        -1690e-4,
+        0,
+        3.56e-3,
+        std::numbers::pi_v<T> / 4,
+        1,
+        std::numbers::pi_v<T> / 2,
+        2,
+        std::numbers::e_v<T>,
+        std::numbers::pi_v<T>,
+        5.67,
+        10,
+        78,
+        127,
+    };
+};
+
+}  // namespace micromouse::tests
+
+#endif  // UNITTESTS_VALUES_H


### PR DESCRIPTION
Add various utilities for handling (cyclic) value ranges and creating strong types.

* `StronglyTyped` - A base class for creating strongly typed primitives (and other types).

  Usage:
  ```cpp
  using MyStrongInt = StronglyTyped<int>;
  ```

* `ValueRange` - A helper for handling `clamp`/`fix_cycle` (modulo arithmetic) operations on values in a range.
* `ConstrainedValue` - A wrapper for variables that have values within a value range.
* `AngleRange` - A `ValueRange` of `[-pi, pi)`.
* `Angle` - A `ConstrainedValue` with `AngleRange`.
* Physical unit handling:
  * `PhysicalSize` - A class template representing physical sizes (distance, time, velocity, etc.).
  * `unit_cast` - Converts a `PhysicalSize` to a different inner representation or ratio.